### PR TITLE
Migrate 'docker-compose' to v2.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,10 +15,6 @@ machine:
     DEPLOY_DOCKER: ${DEPLOY_DOCKER:=0}
   pre:
     - mkdir -p ~/logs
-    # Need latest Docker version for features like `--build-arg` to work (CircleCI by default works with outdated version)
-    - |
-      sudo curl -L -o /usr/bin/docker 'http://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.0-circleci'
-      sudo chmod 0755 /usr/bin/docker
   services:
     - docker
 

--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,10 @@ machine:
     DEPLOY_DOCKER: ${DEPLOY_DOCKER:=0}
   pre:
     - mkdir -p ~/logs
+    # Need latest Docker version for features like `--build-arg` to work (CircleCI by default works with outdated version)
+    - |
+      sudo curl -L -o /usr/bin/docker 'http://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.0-circleci'
+      sudo chmod 0755 /usr/bin/docker
   services:
     - docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   api:
     image: stackstorm/st2api
-    links:
+    depends_on:
       - mongo
       - rabbitmq
     volumes_from:
@@ -12,7 +12,7 @@ services:
 
   auth:
     image: stackstorm/st2auth
-    links:
+    depends_on:
       - api
       - mongo
     volumes_from:
@@ -20,7 +20,7 @@ services:
 
   stream:
     image: stackstorm/st2stream
-    links:
+    depends_on:
       - mongo
       - rabbitmq
     volumes_from:
@@ -28,7 +28,7 @@ services:
 
   notifier:
     image: stackstorm/st2notifier
-    links:
+    depends_on:
       - api
       - mongo
       - rabbitmq
@@ -37,7 +37,7 @@ services:
 
   resultstracker:
     image: stackstorm/st2resultstracker
-    links:
+    depends_on:
       - api
       - mongo
       - rabbitmq
@@ -46,7 +46,7 @@ services:
 
   rulesengine:
     image: stackstorm/st2rulesengine
-    links:
+    depends_on:
       - api
       - mongo
       - rabbitmq
@@ -55,7 +55,7 @@ services:
 
   sensorcontainer:
     image: stackstorm/st2sensorcontainer
-    links:
+    depends_on:
       - api
       - mongo
       - rabbitmq
@@ -64,7 +64,7 @@ services:
 
   garbagecollector:
     image: stackstorm/st2garbagecollector
-    links:
+    depends_on:
       - api
       - mongo
       - rabbitmq
@@ -73,7 +73,7 @@ services:
 
   actionrunner:
     image: stackstorm/st2actionrunner
-    links:
+    depends_on:
       - api
       - auth
       - mongo
@@ -94,13 +94,13 @@ services:
     volumes:
       - /etc/st2
       - /opt/stackstorm
-    links:
+    depends_on:
       - rabbitmq
       - mongo
 
   ## Client container
   client:
     build: ./client
-    links:
+    depends_on:
       - api
       - auth

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,102 +1,106 @@
-api:
-  image: stackstorm/st2api
-  links:
-    - mongo
-    - rabbitmq
-  volumes_from:
-    - data
+version: '2'
 
-auth:
-  image: stackstorm/st2auth
-  links:
-    - api
-    - mongo
-  volumes_from:
-    - data
+services:
 
-stream:
-  image: stackstorm/st2stream
-  links:
-    - mongo
-    - rabbitmq
-  volumes_from:
-    - data
+  api:
+    image: stackstorm/st2api
+    links:
+      - mongo
+      - rabbitmq
+    volumes_from:
+      - data
 
-notifier:
-  image: stackstorm/st2notifier
-  links:
-    - api
-    - mongo
-    - rabbitmq
-  volumes_from:
-    - data
+  auth:
+    image: stackstorm/st2auth
+    links:
+      - api
+      - mongo
+    volumes_from:
+      - data
 
-resultstracker:
-  image: stackstorm/st2resultstracker
-  links:
-    - api
-    - mongo
-    - rabbitmq
-  volumes_from:
-    - data
+  stream:
+    image: stackstorm/st2stream
+    links:
+      - mongo
+      - rabbitmq
+    volumes_from:
+      - data
 
-rulesengine:
-  image: stackstorm/st2rulesengine
-  links:
-    - api
-    - mongo
-    - rabbitmq
-  volumes_from:
-    - data
+  notifier:
+    image: stackstorm/st2notifier
+    links:
+      - api
+      - mongo
+      - rabbitmq
+    volumes_from:
+      - data
 
-sensorcontainer:
-  image: stackstorm/st2sensorcontainer
-  links:
-    - api
-    - mongo
-    - rabbitmq
-  volumes_from:
-    - data
+  resultstracker:
+    image: stackstorm/st2resultstracker
+    links:
+      - api
+      - mongo
+      - rabbitmq
+    volumes_from:
+      - data
 
-garbagecollector:
-  image: stackstorm/st2garbagecollector
-  links:
-    - api
-    - mongo
-    - rabbitmq
-  volumes_from:
-    - data
+  rulesengine:
+    image: stackstorm/st2rulesengine
+    links:
+      - api
+      - mongo
+      - rabbitmq
+    volumes_from:
+      - data
 
-actionrunner:
-  image: stackstorm/st2actionrunner
-  links:
-    - api
-    - auth
-    - mongo
-    - rabbitmq
-  volumes_from:
-    - data
+  sensorcontainer:
+    image: stackstorm/st2sensorcontainer
+    links:
+      - api
+      - mongo
+      - rabbitmq
+    volumes_from:
+      - data
 
-## External Services
-mongo:
-  image: mongo:3.2
+  garbagecollector:
+    image: stackstorm/st2garbagecollector
+    links:
+      - api
+      - mongo
+      - rabbitmq
+    volumes_from:
+      - data
 
-rabbitmq:
-  image: rabbitmq
+  actionrunner:
+    image: stackstorm/st2actionrunner
+    links:
+      - api
+      - auth
+      - mongo
+      - rabbitmq
+    volumes_from:
+      - data
 
-## Data container
-data:
-  build: ./data
-  volumes:
-    - /etc/st2
-    - /opt/stackstorm
-  links:
-    - rabbitmq
-    - mongo
+  ## External Services
+  mongo:
+    image: mongo:3.2
 
-## Client container
-client:
-  build: ./client
-  links:
-    - api
-    - auth
+  rabbitmq:
+    image: rabbitmq
+
+  ## Data container
+  data:
+    build: ./data
+    volumes:
+      - /etc/st2
+      - /opt/stackstorm
+    links:
+      - rabbitmq
+      - mongo
+
+  ## Client container
+  client:
+    build: ./client
+    links:
+      - api
+      - auth


### PR DESCRIPTION
See https://docs.docker.com/compose/compose-file/#/version-2 for reference.

> Version 2 files are supported by Compose 1.6.0+ and require a Docker Engine of version 1.10.0+.

We could also migrate to **[2.1](https://docs.docker.com/compose/compose-file/#/version-21)**, but it requires:

> An upgrade of version 2 that introduces new parameters only available with Docker Engine version 1.12.0+

WDYT @enykeev @armab ?