### PR TITLE
Upgrade pip from 9.x to latest 19.x

### DIFF
--- a/buildpack/bionic/Dockerfile
+++ b/buildpack/bionic/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update -y
 RUN apt-get -y install build-essential python2.7-dev python2.7 python3-dev python3 python3-virtualenv python3-pip && \
     rm -rf /root/.cache
 
-# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+# Install fresh pip and co
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
       pip3 install --upgrade requests[security] && rm -rf /root/.cache
 
 # Install debian build tools

--- a/buildpack/centos6/Dockerfile
+++ b/buildpack/centos6/Dockerfile
@@ -49,7 +49,7 @@ RUN wget https://bintray.com/stackstorm/el6/rpm -O /etc/yum.repos.d/stackstorm-e
 
 ENV PATH=/usr/share/python/st2python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN wget -qO - https://bootstrap.pypa.io/get-pip.py | python && \
-    pip install --upgrade "pip>=9.0.0,<10.0.0" && \
+    pip install --upgrade "pip>=19.0.0,<20.0.0" && \
     pip install setuptools virtualenv && \
     rm -rf /root/.cache
 

--- a/buildpack/centos7/Dockerfile
+++ b/buildpack/centos7/Dockerfile
@@ -45,7 +45,7 @@ RUN yum -y install \
 # Python and tools
 RUN yum -y install python-devel && \
     wget -qO - https://bootstrap.pypa.io/get-pip.py | python && \
-    pip install --upgrade "pip>=9.0.0,<10.0.0" && \
+    pip install --upgrade "pip>=19.0.0,<20.0.0" && \
     pip install setuptools virtualenv && \
     rm -rf /root/.cache
 

--- a/buildpack/trusty/Dockerfile
+++ b/buildpack/trusty/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -y
 # Install python development
 RUN apt-get -y install build-essential python2.7-dev python2.7 && \
     wget -qO - https://bootstrap.pypa.io/get-pip.py | python && \
-    pip install --upgrade "pip>=9.0.0,<10.0.0" && \
+    pip install --upgrade "pip>=19.0.0,<20.0.0" && \
     pip install setuptools virtualenv && \
     rm -rf /root/.cache
 

--- a/packagingbuild/Dockerfile.debian
+++ b/packagingbuild/Dockerfile.debian
@@ -15,12 +15,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
         devscripts debhelper dh-make && apt-get clean
 
 # Install fresh pip and co
-# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
 {% if version in ('bionic') -%}
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
       pip3 install --upgrade requests[security] && rm -rf /root/.cache
 {%- else -%}
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
       pip install --upgrade requests[security] && rm -rf /root/.cache
 {%- endif %}
 

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -110,9 +110,8 @@ RUN wget https://bintray.com/stackstorm/el6/rpm -O /etc/yum.repos.d/stackstorm-e
       yum -y install st2python && rm -rf /tmp/*
 
 # Install fresh pip and co
-# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
 RUN PATH=/usr/share/python/st2python/bin:$PATH bash -c \
-      "curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+      "curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
         pip install --upgrade requests[security] venvctrl" \
     && rm -rf /root/.cache
 
@@ -122,8 +121,7 @@ RUN PATH=/usr/share/python/st2python/bin:$PATH bash -c \
 RUN yum -y install python-devel rpmdevtools
 
 # Install fresh pip and co
-# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
       pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 {%- else -%}

--- a/packagingbuild/bionic/Dockerfile
+++ b/packagingbuild/bionic/Dockerfile
@@ -45,8 +45,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
         devscripts debhelper dh-make && apt-get clean
 
 # Install fresh pip and co
-# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
       pip3 install --upgrade requests[security] && rm -rf /root/.cache
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites

--- a/packagingbuild/centos6/Dockerfile
+++ b/packagingbuild/centos6/Dockerfile
@@ -87,9 +87,8 @@ RUN wget https://bintray.com/stackstorm/el6/rpm -O /etc/yum.repos.d/stackstorm-e
       yum -y install st2python && rm -rf /tmp/*
 
 # Install fresh pip and co
-# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
 RUN PATH=/usr/share/python/st2python/bin:$PATH bash -c \
-      "curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+      "curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
         pip install --upgrade requests[security] venvctrl" \
     && rm -rf /root/.cache
 

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -83,8 +83,7 @@ RUN yum -y install nc net-tools
 RUN yum -y install python-devel rpmdevtools
 
 # Install fresh pip and co
-# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
       pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 VOLUME ['/home/busybee/build']

--- a/packagingbuild/trusty/Dockerfile
+++ b/packagingbuild/trusty/Dockerfile
@@ -43,8 +43,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
         devscripts debhelper dh-make && apt-get clean
 
 # Install fresh pip and co
-# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
       pip install --upgrade requests[security] && rm -rf /root/.cache
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -43,8 +43,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
         devscripts debhelper dh-make && apt-get clean
 
 # Install fresh pip and co
-# pin virtualenv to '15.1.0' (installs pip 9) due to dh-virtualenv incompatibility with pip 10.0
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==15.1.0 pip==9.0.1 wheel==0.29.0 setuptools==28.0.0; \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
       pip install --upgrade requests[security] && rm -rf /root/.cache
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites


### PR DESCRIPTION
This PR upgrades pip from previously strictly pinned 9.x to currently latest one.

Part of StackStorm/st2#4681 and https://github.com/StackStorm/st2-packages/pull/614
