### PR TITLE
Make Debian frontend noninteractive option permanent

### DIFF
--- a/packagingbuild/bionic/Dockerfile
+++ b/packagingbuild/bionic/Dockerfile
@@ -1,5 +1,9 @@
 FROM buildpack-deps:bionic
 
+# Make noninteractive setting permanent
+ENV DEBIAN_FRONTEND noninteractive
+RUN debconf-set-selections -v <<< 'debconf debconf/frontend select Noninteractive'
+
 # Enable remote pubkey access
 RUN mkdir /root/.ssh && chmod 700 /root/.ssh && \
     echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCdCmmPjsOBWRXc+PKdgDRrsciNjp25zTacyz8Gdkln2ma046brOYXAphhp/85DKgHtANBBt3cl4+HnpDbmAfyq2qZT7hWzAbMxtq0Sj+yyFyUdreXoe4gEKyxpV6o8p/R/XzEcawvqX/vFc5EIFmvTdamxZs9DQmOE5AZMzUB18Kerkrb0/arUcZ8iMi9Ng9a18avow+7oUFZ6Oub7ISz/dkIRojaKO/2paJZ4p+v7ZLn7Hq8TUeBkgAlx872oh8J8linhIq17zK6x4MGL8qiurp2hnfe0cuCxwcsYGy+4DfK51+E2vks6FprCIfF5hIdz26euPn67/YpM0F0b5nXF busybee@drone" >> /root/.ssh/authorized_keys
@@ -8,7 +12,7 @@ RUN mkdir /root/.ssh && chmod 700 /root/.ssh && \
 COPY busybee*  /root/.ssh/
 RUN chmod 600 /root/.ssh/busybee
 
-RUN DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
+RUN apt-get -y update && \
     apt-get install -y openssh-server sudo && \
     mkdir /var/run/sshd
 
@@ -23,7 +27,7 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
 
 # install core software for packaging and ssh communication
 RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
-    DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
+    apt-get -y update && \
     apt-get -y install gdebi-core sshpass cron \
       netcat net-tools
 
@@ -35,13 +39,13 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 
 
 # install python development
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+RUN apt-get update && \
     apt-get -y install build-essential \
         python python-virtualenv \
         python3 python3-virtualenv python3-pip
 
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+RUN apt-get -y install \
         devscripts debhelper dh-make && apt-get clean
 
 # Install fresh pip and co
@@ -49,14 +53,14 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip
       pip3 install --upgrade requests[security] && rm -rf /root/.cache
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+RUN apt-get -y install \
         python-setuptools python-mock && \
         apt-get clean && \
         git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \
         dpkg-buildpackage -b -uc -us && dpkg -i ../dh-virtualenv_*.deb && \
           rm -rf /tmp/dh-virtualenv*
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install dh-systemd && apt-get clean
+RUN apt-get -y install dh-systemd && apt-get clean
 
 VOLUME ['/home/busybee/build']
 EXPOSE 22

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -1,5 +1,9 @@
 FROM buildpack-deps:xenial
 
+# Make noninteractive setting permanent
+ENV DEBIAN_FRONTEND noninteractive
+RUN debconf-set-selections -v <<< 'debconf debconf/frontend select Noninteractive'
+
 # Enable remote pubkey access
 RUN mkdir /root/.ssh && chmod 700 /root/.ssh && \
     echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCdCmmPjsOBWRXc+PKdgDRrsciNjp25zTacyz8Gdkln2ma046brOYXAphhp/85DKgHtANBBt3cl4+HnpDbmAfyq2qZT7hWzAbMxtq0Sj+yyFyUdreXoe4gEKyxpV6o8p/R/XzEcawvqX/vFc5EIFmvTdamxZs9DQmOE5AZMzUB18Kerkrb0/arUcZ8iMi9Ng9a18avow+7oUFZ6Oub7ISz/dkIRojaKO/2paJZ4p+v7ZLn7Hq8TUeBkgAlx872oh8J8linhIq17zK6x4MGL8qiurp2hnfe0cuCxwcsYGy+4DfK51+E2vks6FprCIfF5hIdz26euPn67/YpM0F0b5nXF busybee@drone" >> /root/.ssh/authorized_keys
@@ -8,7 +12,7 @@ RUN mkdir /root/.ssh && chmod 700 /root/.ssh && \
 COPY busybee*  /root/.ssh/
 RUN chmod 600 /root/.ssh/busybee
 
-RUN DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
+RUN apt-get -y update && \
     apt-get install -y openssh-server sudo && \
     mkdir /var/run/sshd
 
@@ -23,7 +27,7 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
 
 # install core software for packaging and ssh communication
 RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
-    DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
+    apt-get -y update && \
     apt-get -y install gdebi-core sshpass cron \
       netcat net-tools
 
@@ -35,11 +39,11 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 
 
 # install python development
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+RUN apt-get update && \
     apt-get -y install build-essential python-dev python python-virtualenv
 
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+RUN apt-get -y install \
         devscripts debhelper dh-make && apt-get clean
 
 # Install fresh pip and co
@@ -47,14 +51,14 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==16.6.0 pip=
       pip install --upgrade requests[security] && rm -rf /root/.cache
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+RUN apt-get -y install \
         python-setuptools python-mock && \
         apt-get clean && \
         git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \
         dpkg-buildpackage -b -uc -us && dpkg -i ../dh-virtualenv_*.deb && \
           rm -rf /tmp/dh-virtualenv*
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install dh-systemd && apt-get clean
+RUN apt-get -y install dh-systemd && apt-get clean
 
 VOLUME ['/home/busybee/build']
 EXPOSE 22

--- a/packagingtest/bionic/systemd/Dockerfile
+++ b/packagingtest/bionic/systemd/Dockerfile
@@ -2,7 +2,10 @@ FROM buildpack-deps:bionic
 
 ENV container docker
 ENV TERM xterm
+
+# Make noninteractive setting permanent
 ENV DEBIAN_FRONTEND noninteractive
+RUN debconf-set-selections -v <<< 'debconf debconf/frontend select Noninteractive'
 
 RUN apt-get -y update
 
@@ -38,7 +41,7 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
     apt-get -y install gdebi-core sshpass cron netcat net-tools iproute2
 
 # install netbase package (includes /etc/protocols and other files we rely on)
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install netbase
+RUN apt-get -y install netbase
 
 RUN find /etc/systemd/system \
          /lib/systemd/system \

--- a/packagingtest/xenial/systemd/Dockerfile
+++ b/packagingtest/xenial/systemd/Dockerfile
@@ -2,7 +2,10 @@ FROM buildpack-deps:xenial
 
 ENV container docker
 ENV TERM xterm
+
+# Make noninteractive setting permanent
 ENV DEBIAN_FRONTEND noninteractive
+RUN debconf-set-selections -v <<< 'debconf debconf/frontend select Noninteractive'
 
 RUN apt-get -y update
 
@@ -38,7 +41,7 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
     apt-get -y install gdebi-core sshpass cron netcat net-tools iproute
 
 # install netbase package (includes /etc/protocols and other files we rely on)
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install netbase
+RUN apt-get -y install netbase
 
 RUN find /etc/systemd/system \
          /lib/systemd/system \


### PR DESCRIPTION
Closes StackStorm/st2-packages#615

Because we SSH into running containers and execute commands, setting ENV variable `noninteractive` in Docker ENV is not enough. And so adding non-interactive optiont on OS-level defaults helps in this situation.
