### PR TITLE
EL8 updates to succeed centos8 package builds, fix some dockerfile templating issues

### DIFF
--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -134,12 +134,13 @@ RUN PATH=/usr/share/python/st2python/bin:$PATH bash -c \
 {%- elif dist in ('centos', 'fedora') -%}
 
 # Install development tools and python for EL8
-RUN yum -y install python{%- if (version == '8') -%}3 python2 python2-devel gcc python3{%- endif%}-devel rpmdevtools && \
-    sudo alternatives --set python /usr/bin/python2
+RUN yum -y install python{%- if (version == '8') -%}3 python2 python2-devel gcc python3{%- else %}2 \
+    gcc python2{%- endif%}-devel rpmdevtools {%- if (version == '8') %} && \
+    sudo alternatives --set python /usr/bin/python2{%- endif%}
 
 # Install fresh pip and certs
 RUN curl https://bootstrap.pypa.io/get-pip.py | \
-    python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
+    python{%- if (version == '8') -%}2{%- endif%} - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
     pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 {%- else -%}

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -56,7 +56,7 @@ RUN yum -y install \
     libxslt-devel \
     {% if (version == '7' or version == '6') -%}
     libyaml-devel \
-    {%- endif %}
+    {%- endif -%}
     make \
     mysql-devel \
     ncurses-devel \

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -136,13 +136,13 @@ RUN PATH=/usr/share/python/st2python/bin:$PATH bash -c \
 {%- elif dist in ('centos', 'fedora') -%}
 
 # Install development tools and python for EL8
-RUN yum -y install python{%- if (version == '8') -%}3 python2 python3{%- endif %}-devel rpmdevtools && \
+RUN yum -y install python{%- if (version == '8') -%}3 python2 python2-devel gcc python3 {%- endif%}-devel rpmdevtools && \
     sudo alternatives --set python /usr/bin/python2
 
 # Install fresh pip and certs
 RUN curl https://bootstrap.pypa.io/get-pip.py | \
-    python{%- if (version == '8') -%}3{%- endif %} - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
-    pip{%- if (version == '8') -%}3{%- endif %} install --upgrade requests[security] venvctrl && rm -rf /root/.cache
+    python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
+    pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 {%- else -%}
 {% include "Dockerfile.debian" -%}

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -45,8 +45,7 @@ RUN yum -y install \
     {%- if (version == '7' or version == '6') -%}
     ImageMagick \
     ImageMagick-devel \
-    {%- endif -%}
-
+    {%- endif %}
     libcurl-devel \
     libevent-devel \
     libffi-devel \
@@ -55,10 +54,9 @@ RUN yum -y install \
     libwebp-devel \
     libxml2-devel \
     libxslt-devel \
-    {%- if (version == '7' or version == '6') -%}
+    {% if (version == '7' or version == '6') -%}
     libyaml-devel \
-    {%- endif -%}
-
+    {%- endif %}
     make \
     mysql-devel \
     ncurses-devel \
@@ -136,7 +134,7 @@ RUN PATH=/usr/share/python/st2python/bin:$PATH bash -c \
 {%- elif dist in ('centos', 'fedora') -%}
 
 # Install development tools and python for EL8
-RUN yum -y install python{%- if (version == '8') -%}3 python2 python2-devel gcc python3 {%- endif%}-devel rpmdevtools && \
+RUN yum -y install python{%- if (version == '8') -%}3 python2 python2-devel gcc python3{%- endif%}-devel rpmdevtools && \
     sudo alternatives --set python /usr/bin/python2
 
 # Install fresh pip and certs

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -134,8 +134,8 @@ RUN PATH=/usr/share/python/st2python/bin:$PATH bash -c \
 {%- elif dist in ('centos', 'fedora') -%}
 
 # Install development tools and python for EL8
-RUN yum -y install python{%- if (version == '8') -%}3 python2 python2-devel gcc python3{%- else %}2 \
-    gcc python2{%- endif%}-devel rpmdevtools {%- if (version == '8') %} && \
+RUN yum -y install python{%- if (version == '8') -%}3 python2 python2-devel python3{%- else %}2 \
+    python2{%- endif%}-devel rpmdevtools {%- if (version == '8') %} && \
     sudo alternatives --set python /usr/bin/python2{%- endif%}
 
 # Install fresh pip and certs

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -83,10 +83,10 @@ RUN yum -y install nc net-tools
 RUN yum -y install python-devel rpmdevtools
 
 # Install fresh pip and co
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
       pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
-VOLUME ['/home/busybee/build']
+VOLUME ["/home/busybee/build"]
 EXPOSE 22
 
 # Run ssh daemon in foreground and wait for bees to connect.

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -33,8 +33,7 @@ RUN yum -y install \
     libwebp-devel \
     libxml2-devel \
     libxslt-devel \
-    libyaml-devel \
-    make \
+    libyaml-devel \make \
     mysql-devel \
     ncurses-devel \
     openssl-devel \
@@ -79,7 +78,8 @@ RUN yum -y install nc net-tools
 #
 
 # Install development tools and python for EL8
-RUN yum -y install python2 gcc python2-devel rpmdevtools
+RUN yum -y install python2 \
+    python2-devel rpmdevtools
 
 # Install fresh pip and certs
 RUN curl https://bootstrap.pypa.io/get-pip.py | \

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -6,12 +6,12 @@ RUN yum -y install \
     curl \
     wget
 
-RUN yum -y install \
-    bzr \
-    git \
+RUN yum -y install \bzr \git \
     mercurial \
     openssh \
     subversion
+
+    
 
 # Build tools
 RUN yum -y install \
@@ -23,8 +23,7 @@ RUN yum -y install \
     gcc \
     gcc-c++ \
     glib2-devel \
-    glibc-devel \
-    ImageMagick \
+    glibc-devel \ImageMagick \
     ImageMagick-devel \
     libcurl-devel \
     libevent-devel \
@@ -79,12 +78,13 @@ RUN yum -y install nc net-tools
 #   - SSH access for build executor.
 #
 
-# Install development tools
-RUN yum -y install python-devel rpmdevtools
+# Install development tools and python for EL8
+RUN yum -y install python2 gcc python2-devel rpmdevtools
 
-# Install fresh pip and co
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
-      pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
+# Install fresh pip and certs
+RUN curl https://bootstrap.pypa.io/get-pip.py | \
+    python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
+    pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 VOLUME ["/home/busybee/build"]
 EXPOSE 22

--- a/packagingbuild/centos8/Dockerfile
+++ b/packagingbuild/centos8/Dockerfile
@@ -85,13 +85,13 @@ RUN yum -y install nc net-tools
 #
 
 # Install development tools and python for EL8
-RUN yum -y install python3 python2 python3-devel rpmdevtools && \
+RUN yum -y install python3 python2 python2-devel gcc python3-devel rpmdevtools && \
     sudo alternatives --set python /usr/bin/python2
 
 # Install fresh pip and certs
 RUN curl https://bootstrap.pypa.io/get-pip.py | \
-    python3 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
-    pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
+    python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
+    pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 VOLUME ["/home/busybee/build"]
 EXPOSE 22

--- a/packagingbuild/centos8/Dockerfile
+++ b/packagingbuild/centos8/Dockerfile
@@ -87,7 +87,7 @@ RUN yum -y install nc net-tools
 #
 
 # Install development tools and python for EL8
-RUN yum -y install python3 python2 python2-devel gcc python3-devel rpmdevtools && \
+RUN yum -y install python3 python2 python2-devel python3-devel rpmdevtools && \
     sudo alternatives --set python /usr/bin/python2
 
 # Install fresh pip and certs

--- a/packagingbuild/centos8/Dockerfile
+++ b/packagingbuild/centos8/Dockerfile
@@ -33,14 +33,17 @@ RUN yum -y install \
     gcc \
     gcc-c++ \
     glib2-devel \
-    glibc-devel \libcurl-devel \
+    glibc-devel \
+    libcurl-devel \
     libevent-devel \
     libffi-devel \
     libjpeg-devel \
     libtool \
     libwebp-devel \
     libxml2-devel \
-    libxslt-devel \make \
+    libxslt-devel \
+    
+    make \
     mysql-devel \
     ncurses-devel \
     openssl-devel \

--- a/packagingbuild/centos8/Dockerfile
+++ b/packagingbuild/centos8/Dockerfile
@@ -42,7 +42,6 @@ RUN yum -y install \
     libwebp-devel \
     libxml2-devel \
     libxslt-devel \
-    
     make \
     mysql-devel \
     ncurses-devel \

--- a/packagingbuild/centos8/Dockerfile
+++ b/packagingbuild/centos8/Dockerfile
@@ -93,7 +93,7 @@ RUN yum -y install python3 python2 python2-devel gcc python3-devel rpmdevtools &
 
 # Install fresh pip and certs
 RUN curl https://bootstrap.pypa.io/get-pip.py | \
-    python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
+    python2 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
     pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 VOLUME ["/home/busybee/build"]

--- a/packagingtest/Dockerfile.common
+++ b/packagingtest/Dockerfile.common
@@ -62,10 +62,6 @@ RUN yum -y install \
     openssl-devel \
     patch \
     postgresql-devel \
-    {% if (version == '8') -%}
-    python2-devel \
-    python3-devel \
-    {%- endif %}
     readline-devel \
     sqlite-devel \
     xz \

--- a/packagingtest/Dockerfile.common
+++ b/packagingtest/Dockerfile.common
@@ -44,7 +44,7 @@ RUN yum -y install \
     {%- if (version == '7' or version == '6') -%}
     ImageMagick \
     ImageMagick-devel \
-    {%- endif -%}
+    {%- endif %}
     libcurl-devel \
     libevent-devel \
     libffi-devel \
@@ -55,14 +55,17 @@ RUN yum -y install \
     libxslt-devel \
     {%- if (version == '7' or version == '6') -%}
     libyaml-devel \
-    {%- endif -%}
-
+    {%- endif %}
     make \
     mysql-devel \
     ncurses-devel \
     openssl-devel \
     patch \
     postgresql-devel \
+    {% if (version == '8') -%}
+    python2-devel \
+    python3-devel \
+    {%- endif %}
     readline-devel \
     sqlite-devel \
     xz \
@@ -85,7 +88,8 @@ RUN chmod 600 /root/.ssh/busybee
 {% if dist in ('centos', 'fedora') -%}
 RUN yum -y install openssh-server sudo && \
   ssh-keygen -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key
-{%- else -%}
+{%- else %}
+
 RUN DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
     apt-get install -y openssh-server sudo && \
     mkdir /var/run/sshd

--- a/packagingtest/Dockerfile.template-systemd
+++ b/packagingtest/Dockerfile.template-systemd
@@ -4,7 +4,7 @@
 ENV container docker
 
 RUN yum -y update; \
-    yum -y install systemd; yum clean all;
+    yum -y install systemd; yum clean all
 
 RUN cd /lib/systemd/system/sysinit.target.wants/; ls -1 | grep -v systemd-tmpfiles-setup.service | xargs rm; \ {%- if (version == '6') -%}rm -f /lib/systemd/system/multi-user.target.wants/*; \{%- endif %}
     rm -f /etc/systemd/system/*.wants/*;\

--- a/packagingtest/centos8/systemd/Dockerfile
+++ b/packagingtest/centos8/systemd/Dockerfile
@@ -48,8 +48,6 @@ RUN yum -y install \
     openssl-devel \
     patch \
     postgresql-devel \
-    python2-devel \
-    python3-devel \
     readline-devel \
     sqlite-devel \
     xz \

--- a/packagingtest/centos8/systemd/Dockerfile
+++ b/packagingtest/centos8/systemd/Dockerfile
@@ -33,19 +33,23 @@ RUN yum -y install \
     gcc \
     gcc-c++ \
     glib2-devel \
-    glibc-devel \libcurl-devel \
+    glibc-devel \
+    libcurl-devel \
     libevent-devel \
     libffi-devel \
     libjpeg-devel \
     libtool \
     libwebp-devel \
     libxml2-devel \
-    libxslt-devel \make \
+    libxslt-devel \
+    make \
     mysql-devel \
     ncurses-devel \
     openssl-devel \
     patch \
     postgresql-devel \
+    python2-devel \
+    python3-devel \
     readline-devel \
     sqlite-devel \
     xz \
@@ -81,7 +85,7 @@ RUN yum -y install nc net-tools
 ENV container docker
 
 RUN yum -y update; \
-    yum -y install systemd; yum clean all;
+    yum -y install systemd; yum clean all
 
 RUN cd /lib/systemd/system/sysinit.target.wants/; ls -1 | grep -v systemd-tmpfiles-setup.service | xargs rm; \
     rm -f /etc/systemd/system/*.wants/*;\


### PR DESCRIPTION
- EL8 dockerfiles had a some mixups between py2 and py3 causing rpmbuild command to fail. Defaulting to py2 to get everything working. Can consider py3 once py2 is working for packaging
- Fixed a templating error where the `/home/busybee/` folder was getting created with brackets eg.: `[/home/busybee/]`
- Other packages needs for EL8
