### PR TITLE
updates for EL8 rpmbuild

### DIFF
--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -139,7 +139,7 @@ RUN PATH=/usr/share/python/st2python/bin:$PATH bash -c \
 RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
     pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
 
-RUN pip3 install requests[security] venvctrl --upgrade && rm -rf /root/.cache
+RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 {%- elif version in ('7', '6') -%}
 # Install development tools and python2 for EL <=7

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -134,15 +134,22 @@ RUN PATH=/usr/share/python/st2python/bin:$PATH bash -c \
 
 {%- elif dist in ('centos', 'fedora') -%}
 
-# Install development tools and python for EL8
-RUN yum -y install python{%- if (version == '8') -%}3 python2 python2-devel python3{%- else %}2 \
-    python2{%- endif%}-devel rpmdevtools {%- if (version == '8') %} && \
-    sudo alternatives --set python /usr/bin/python2{%- endif%}
+{% if (version == '8') -%}
+# Install development tools and python3 for EL8
+RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
+    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+
+RUN pip3 install requests[security] venvctrl --upgrade && rm -rf /root/.cache
+
+{%- elif version in ('7', '6') -%}
+# Install development tools and python2 for EL <=7
+RUN yum -y install python2 python2-devel rpmdevtools
 
 # Install fresh pip and certs
 RUN curl https://bootstrap.pypa.io/get-pip.py | \
-    python{%- if (version == '8') -%}2{%- endif%} - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
-    pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
+    python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
+RUN pip3 install requests[security] venvctrl --upgrade && rm -rf /root/.cache
+{%- endif %}
 
 {%- else -%}
 {% include "Dockerfile.debian" -%}

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -148,7 +148,7 @@ RUN yum -y install python2 python2-devel rpmdevtools
 # Install fresh pip and certs
 RUN curl https://bootstrap.pypa.io/get-pip.py | \
     python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
-RUN pip3 install requests[security] venvctrl --upgrade && rm -rf /root/.cache
+    pip install requests[security] venvctrl --upgrade && rm -rf /root/.cache
 {%- endif %}
 
 {%- else -%}

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -148,7 +148,7 @@ RUN yum -y install python2 python2-devel rpmdevtools
 # Install fresh pip and certs
 RUN curl https://bootstrap.pypa.io/get-pip.py | \
     python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
-    pip install requests[security] venvctrl --upgrade && rm -rf /root/.cache
+    pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 {%- endif %}
 
 {%- else -%}

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -77,14 +77,13 @@ RUN yum -y install nc net-tools
 #   - SSH access for build executor.
 #
 
-# Install development tools and python for EL8
-RUN yum -y install python2 \
-    python2-devel rpmdevtools
+# Install development tools and python2 for EL <=7
+RUN yum -y install python2 python2-devel rpmdevtools
 
 # Install fresh pip and certs
 RUN curl https://bootstrap.pypa.io/get-pip.py | \
     python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
-    pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
+RUN pip3 install requests[security] venvctrl --upgrade && rm -rf /root/.cache
 
 VOLUME ["/home/busybee/build"]
 EXPOSE 22

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -83,7 +83,7 @@ RUN yum -y install python2 python2-devel rpmdevtools
 # Install fresh pip and certs
 RUN curl https://bootstrap.pypa.io/get-pip.py | \
     python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
-RUN pip3 install requests[security] venvctrl --upgrade && rm -rf /root/.cache
+    pip install requests[security] venvctrl --upgrade && rm -rf /root/.cache
 
 VOLUME ["/home/busybee/build"]
 EXPOSE 22

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -83,7 +83,7 @@ RUN yum -y install python2 python2-devel rpmdevtools
 # Install fresh pip and certs
 RUN curl https://bootstrap.pypa.io/get-pip.py | \
     python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
-    pip install requests[security] venvctrl --upgrade && rm -rf /root/.cache
+    pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 VOLUME ["/home/busybee/build"]
 EXPOSE 22

--- a/packagingbuild/centos8/Dockerfile
+++ b/packagingbuild/centos8/Dockerfile
@@ -87,14 +87,11 @@ RUN yum -y install nc net-tools
 #   - SSH access for build executor.
 #
 
-# Install development tools and python for EL8
-RUN yum -y install python3 python2 python2-devel python3-devel rpmdevtools && \
-    sudo alternatives --set python /usr/bin/python2
+# Install development tools and python3 for EL8
+RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
+    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
 
-# Install fresh pip and certs
-RUN curl https://bootstrap.pypa.io/get-pip.py | \
-    python2 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
-    pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
+RUN pip3 install requests[security] venvctrl --upgrade && rm -rf /root/.cache
 
 VOLUME ["/home/busybee/build"]
 EXPOSE 22

--- a/packagingtest/Dockerfile.common
+++ b/packagingtest/Dockerfile.common
@@ -103,7 +103,6 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
 
 {% if dist in ('centos', 'fedora') -%}
 RUN yum -y install nc net-tools {%- if (version == '8') %} glibc-locale-source && \
-    sudo alternatives --set python /usr/bin/python2 && \
     # -i: specify the locale definition file
     # -f: specify the character set
     localedef -i en_US -f UTF-8 en_US.UTF-8

--- a/packagingtest/centos8/systemd/Dockerfile
+++ b/packagingtest/centos8/systemd/Dockerfile
@@ -80,7 +80,7 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
         echo 'root:docker.io' | chpasswd
 
 RUN yum -y install nc net-tools glibc-locale-source && \
-    sudo alternatives --set python /usr/bin/python2 && \
+
     # -i: specify the locale definition file
     # -f: specify the character set
     localedef -i en_US -f UTF-8 en_US.UTF-8


### PR DESCRIPTION
* Preinstalled some yum packages in EL8 to deal with rpmbuild needs - for when we are in BUILDROOT but not in a venv. Need a few rpms also in order to build with py3 only since we must install it manually. 

* after some research - the folks recommend using the pip installed as a dependency for yum install python3 then updating it. Switched to that approach for EL8