### PR TITLE
Fixed Ubuntu 18 (bionic) container from excluding documentation files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,16 @@ See [packagingbuild/](packagingbuild/)
 `Dockerfiles` with pre-installed init system used to test `.deb` and `.rpm` StackStorm packages in [StackStorm/st2-packages](https://github.com/StackStorm/st2-packages/blob/master/docker-compose.circle.yml) CI/CD.
 
 See [packagingtest/](packagingtest/)
+
+# How To Build Theses Containers (developer)
+
+If you're a developer looking to modify / test / build these containers simply, change into 
+the container's directory and do the following:
+
+``` shell
+cd st2packaging-dockerfiles/packagingbuild/bionic
+docker build -t stackstorm/packagingbuild:bionic .
+
+cd st2packaging-dockerfiles/packagingtest/bionic/systemd
+docker build -t stackstorm/packagingtest:bionic .
+```

--- a/packagingtest/bionic/systemd/Dockerfile
+++ b/packagingtest/bionic/systemd/Dockerfile
@@ -53,6 +53,14 @@ RUN find /etc/systemd/system \
 
 RUN systemctl set-default multi-user.target
 
+# The base Ubuntu 18.04 image contains a file that excludes all documentation
+# from being installed by packages. Specifically /usr/share/doc/*
+# This exclusion prevents our nginx config from being installed in the 'st2' package:
+# /usr/share/doc/st2/conf/nginx/st2.conf
+# This step removes the exclusion configuration so documentation of all future packages
+# will be installed.
+RUN rm -rf /etc/dpkg/dpkg.cfg.d/excludes
+
 COPY setup.sh /sbin/
 
 RUN systemctl preset ssh;


### PR DESCRIPTION
Recently, when testing `puppet-st2` for Ubuntu 18 (bionic) the tests were failing because `/usr/share/doc/st2/conf/nginx/st2.conf` wasn't present after installing the `st2` package.

Turns out, it's because the base Ubuntu container creates a file to exclude documentation (`/etc/dpkg/dpkg.conf.d/excludes`). This PR removes that file so that documentation, including our nginx config, will be installed.

Also added a note in the README about how to build the containers locally (because i got thrown for a loop).