### PR TITLE
Allow docs to be installed in CentOS containers 

### DIFF
--- a/packagingtest/centos6/sshd/Dockerfile
+++ b/packagingtest/centos6/sshd/Dockerfile
@@ -73,6 +73,11 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
 
 RUN yum -y install nc net-tools
 
+# install doc files (/usr/share/docs) when installing yum packages
+# otherwise /usr/share/docs/st2/conf/nginx/st2.conf won't be present
+# https://github.com/docker-library/docs/tree/master/centos#package-documentation
+RUN sed -i '/nodocs/d' /etc/yum.conf
+
 ENV container docker
 
 # we can have ssh

--- a/packagingtest/centos7/systemd/Dockerfile
+++ b/packagingtest/centos7/systemd/Dockerfile
@@ -83,6 +83,11 @@ RUN cd /lib/systemd/system/sysinit.target.wants/; ls -1 | grep -v systemd-tmpfil
     rm -f /lib/systemd/system/anaconda.target.wants/*;\
     systemctl preset sshd;
 
+# install doc files (/usr/share/docs) when installing yum packages
+# otherwise /usr/share/docs/st2/conf/nginx/st2.conf won't be present
+# https://github.com/docker-library/docs/tree/master/centos#package-documentation
+RUN sed -i '/nodocs/d' /etc/yum.conf
+
 # we can have ssh
 EXPOSE 22
 

--- a/packagingtest/centos8/systemd/Dockerfile
+++ b/packagingtest/centos8/systemd/Dockerfile
@@ -114,6 +114,11 @@ RUN cd /lib/systemd/system/sysinit.target.wants/; ls -1 | grep -v systemd-tmpfil
     rm -f /lib/systemd/system/anaconda.target.wants/*;\
     systemctl preset sshd;
 
+# install doc files (/usr/share/docs) when installing yum packages
+# otherwise /usr/share/docs/st2/conf/nginx/st2.conf won't be present
+# https://github.com/docker-library/docs/tree/master/centos#package-documentation
+RUN sed -i '/nodocs/d' /etc/yum.conf
+
 # we can have ssh
 EXPOSE 22
 


### PR DESCRIPTION
Similar to the Ubuntu 18 changes i did yesterday, the CentOS containers need adjusted so they install documentation.

This has been working in Puppet because i built my own docker images on top of this container: https://github.com/StackStorm/puppet-st2/blob/master/build/centos7-puppet6/Dockerfile.kitchen#L21-L24

I would love to remove that customization and have it baked into the base container for all of our testing to utilize.