### PR TITLE
Added APT https transport so we can use APT sources with HTTPS URLs

### DIFF
--- a/packagingtest/bionic/systemd/Dockerfile
+++ b/packagingtest/bionic/systemd/Dockerfile
@@ -40,6 +40,9 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
 RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
     apt-get -y install gdebi-core sshpass cron netcat net-tools iproute2
 
+# install apt https transport so apt sources can be added that refernece https:// URLs
+RUN apt-get -y install apt-transport-https ca-certificates
+
 # install netbase package (includes /etc/protocols and other files we rely on)
 RUN apt-get -y install netbase
 

--- a/packagingtest/xenial/systemd/Dockerfile
+++ b/packagingtest/xenial/systemd/Dockerfile
@@ -40,6 +40,9 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
 RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
     apt-get -y install gdebi-core sshpass cron netcat net-tools iproute
 
+# install apt https transport so apt sources can be added that refernece https:// URLs
+RUN apt-get -y install apt-transport-https ca-certificates
+
 # install netbase package (includes /etc/protocols and other files we rely on)
 RUN apt-get -y install netbase
 


### PR DESCRIPTION
Ran into another problem in the Puppet builds, where Puppet changed their APT source URLs from `http://` -> `https://` . This changed caused our builds to fail because we don't include the `apt-transport-https` plugin, causing the following error:


https://travis-ci.org/github/StackStorm/puppet-st2/jobs/661362365#L2178-L2188
```
       Step 15/23 : RUN sudo apt-get -y update

        ---> Running in b2eb108553fc

       Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease

       Hit:2 http://security.ubuntu.com/ubuntu xenial-security InRelease

       Hit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease

       Hit:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease

       Reading package lists...

       E: The method driver /usr/lib/apt/methods/https could not be found.

       E: Failed to fetch https://apt.puppetlabs.com/dists/xenial/InRelease  

       E: Some index files failed to download. They have been ignored, or old ones used instead.

       The command '/bin/sh -c sudo apt-get -y update' returned a non-zero code: 100
```

This fix was found on Stack Exchange: https://unix.stackexchange.com/questions/263801/apt-get-fails-the-method-driver-usr-lib-apt-methods-https-could-not-be-found