### PR TITLE
Use upstream dh-virtualenv

### DIFF
--- a/packagingbuild/Dockerfile.debian
+++ b/packagingbuild/Dockerfile.debian
@@ -25,12 +25,8 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==16.6.0 pip=
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
-        python-setuptools python-mock && \
-        apt-get clean && \
-        git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
-        cd /tmp/dh-virtualenv && \
-        dpkg-buildpackage -b -uc -us && dpkg -i ../dh-virtualenv_*.deb && \
-          rm -rf /tmp/dh-virtualenv*
+        dh-virtualenv python-setuptools python-mock && \
+        apt-get clean
 
 {%- if version in ('xenial', 'bionic') %}
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install dh-systemd && apt-get clean

--- a/packagingbuild/bionic/Dockerfile
+++ b/packagingbuild/bionic/Dockerfile
@@ -52,15 +52,12 @@ RUN apt-get update && \
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools cryptography; \
       pip3 install --upgrade requests[security] && rm -rf /root/.cache
 
-# We use our dh-virtualenv version, since it fixes shebangd lines rewrites
 RUN apt-get -y install \
-        python-setuptools python-mock && \
-        apt-get clean && \
-        git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
-        cd /tmp/dh-virtualenv && \
-        dpkg-buildpackage -b -uc -us && dpkg -i ../dh-virtualenv_*.deb && \
-          rm -rf /tmp/dh-virtualenv*
-RUN apt-get -y install dh-systemd && apt-get clean
+        dh-systemd \
+        dh-virtualenv \
+        python-setuptools \
+        python-mock \
+        && apt-get clean
 
 VOLUME ['/home/busybee/build']
 EXPOSE 22

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -53,15 +53,13 @@ RUN apt-get update && \
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
       pip3.6 install --upgrade requests[security] && rm -rf /root/.cache
 
-# We use our dh-virtualenv version, since it fixes shebangd lines rewrites
 RUN apt-get -y install \
-        python-virtualenv python-setuptools python-mock && \
-        apt-get clean && \
-        git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
-        cd /tmp/dh-virtualenv && \
-        dpkg-buildpackage -b -uc -us && dpkg -i ../dh-virtualenv_*.deb && \
-          rm -rf /tmp/dh-virtualenv*
-RUN apt-get -y install dh-systemd && apt-get clean
+        dh-systemd \
+        dh-virtualenv \
+        python-virtualenv \
+        python-setuptools \
+        python-mock \
+        && apt-get clean
 
 VOLUME ['/home/busybee/build']
 EXPOSE 22


### PR DESCRIPTION
I don't think we need to use our own fork anymore, since we don't have any shebang lines that are only `#!python`.

The `update.py` script updated more of the `Dockerfile`s than I expected, so I'm not sure if that's normal or not.

Like before, I'm not really sure what I'm doing here, so any help or direction would be more than welcome.