### PR TITLE
Fix pip in the centos8 image for building enterprise packages

### DIFF
--- a/buildpack/centos8/Dockerfile
+++ b/buildpack/centos8/Dockerfile
@@ -52,7 +52,8 @@ RUN yum -y install \
 
 # Python and tools
 RUN yum -y install python3 python3-devel python3-wheel python3-virtualenv && \
-    pip3 install virtualenv==16.6.0 wheel setuptools  && \
+    pip3 install --user --upgrade pip==20.0.2 && \
+    pip3 install --user virtualenv==16.6.0 wheel setuptools  && \
     rm -rf /root/.cache
 
 # St2 package build debs

--- a/buildpack/centos8/Dockerfile
+++ b/buildpack/centos8/Dockerfile
@@ -51,8 +51,8 @@ RUN yum -y install \
 
 
 # Python and tools
-RUN yum -y install python3 python3-devel python3-wheel && \
-    pip3 install virtualenv && \
+RUN yum -y install python3 python3-devel python3-wheel python3-virtualenv && \
+    pip3 install virtualenv==16.6.0 wheel setuptools  && \
     rm -rf /root/.cache
 
 # St2 package build debs

--- a/buildpack/centos8/Dockerfile
+++ b/buildpack/centos8/Dockerfile
@@ -52,9 +52,7 @@ RUN yum -y install \
 
 # Python and tools
 RUN yum -y install python3 python3-devel python3-wheel && \
-    wget -qO - https://bootstrap.pypa.io/get-pip.py | python3 && \
-    pip install --upgrade "pip==19.1.1" && \
-    pip install setuptools virtualenv && \
+    pip3 install virtualenv && \
     rm -rf /root/.cache
 
 # St2 package build debs

--- a/buildpack/centos8/Dockerfile
+++ b/buildpack/centos8/Dockerfile
@@ -52,7 +52,7 @@ RUN yum -y install \
 
 # Python and tools
 RUN yum -y install python3 python3-devel python3-wheel python3-virtualenv && \
-    pip3 install --user --upgrade pip==20.0.2 && \
+    pip3 install --user --upgrade pip==19.1.1 && \
     pip3 install --user virtualenv==16.6.0 wheel setuptools  && \
     rm -rf /root/.cache
 


### PR DESCRIPTION
Use the default pip3 that comes with the python3 install instead of overwriting the pip install.