### PR TITLE
Update to use PY3 on EL7

### DIFF
--- a/buildpack/centos7/Dockerfile
+++ b/buildpack/centos7/Dockerfile
@@ -42,68 +42,13 @@ RUN yum -y install \
     rpmdevtools
 
 
-# Install rpmdevtools and epel-release
-RUN yum -y install rpmdevtools epel-release
+# Python and tools
 RUN yum -y install python-devel && \
     wget -qO - https://bootstrap.pypa.io/get-pip.py | python && \
     pip install --upgrade "pip>=19.0.0,<20.0.0" && \
     pip install setuptools virtualenv && \
     rm -rf /root/.cache
 
-# Install python3
-#RUN pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
-# Following 4 get past wheel errors but get pip errors
-#RUN yum -y install python3 python3-devel python3-virtualenv python3-wheel
-#RUN pip3 install --upgrade pip==19.1.1  && \
-#    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
-#RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
-#
-# With above combination we fail early on the pip import veresion from the python setup.py bdist_wheel command
-#RUN yum -y install python3 python3-devel python3-virtualenv python3-wheel
-#RUN wget -qO get-pip.py https://bootstrap.pypa.io/get-pip.py
-#RUN python3 get-pip.py --force-reinstall && \
-#    pip3 install --upgrade pip==19.1.1 && \
-#    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
-#    rm -rf /root/.cache
-# If we take out virtualenv and wheel from python3 still have same problem...
-#RUN yum -y install python3 python3-devel
-#RUN wget -qO get-pip.py https://bootstrap.pypa.io/get-pip.py
-#RUN python3 get-pip.py --force-reinstall && \
-#    pip3 install --upgrade pip==19.1.1 && \
-#    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
-#    rm -rf /root/.cache
-#    Following fail on early import of pip on __version__ by python3 setup.py bdist_wheel
-#RUN yum -y install python3 python3-devel python3-virtualenv  python3-wheel
-#RUN python3 -m pip uninstall pip -y
-#RUN wget -qO - https://bootstrap.pypa.io/get-pip.py | python3 && \
-#    pip3 install --upgrade "pip>=19.0.0,<20.0.0" && \
-#    pip3 install --upgrade virtualenv==16.6.0 wheel && \
-#    pip3 install setuptools
-#RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
-## This combinations fails reallyl on with no comand bdist_wheel
-#RUN yum -y install python3 python3-devel python3-virtualenv  python3-wheel
-#RUN pip3 install --upgrade "pip==19.1.1" && \
-#    pip3 install --upgrade virtualenv==16.6.0 wheel && \
-#    pip3 install setuptools
-#RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
-#
-# Below combinations fails as gets past problems with initial wheel but then fails on pip internal
-# pip3 wheel --wheel-dir=/code/st2-rbac-backend/build/BUILDROOT/st2-rbac-backend-3.3dev-10.x86_64/opt/stackstorm/share/wheels -r requirements.txt -r test-requirements.txt
-# Traceback (most recent call last):
-#   File "/usr/local/bin/pip3", line 7, in <module>
-#       from pip._internal import main
-#       ModuleNotFoundError: No module named 'pip._internal'
-#       make[1]: Leaving directory `/code/st2-rbac-backend'
-RUN yum -y install python3 python3-devel python3-virtualenv  python3-wheel
-RUN pip3 install --upgrade "pip==19.1.1" && \
-    pip3 install --upgrade virtualenv==16.6.0 && \
-    pip3 install setuptools wheel
-RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
-
-
-# Install python3
-# Install python3
-
 # St2 package build debs
 RUN yum -y install \
-   openldap-devel
+    openldap-devel

--- a/buildpack/centos7/Dockerfile
+++ b/buildpack/centos7/Dockerfile
@@ -42,12 +42,12 @@ RUN yum -y install \
     rpmdevtools
 
 
-# Python and tools
-RUN yum -y install python-devel && \
-    wget -qO - https://bootstrap.pypa.io/get-pip.py | python && \
-    pip install --upgrade "pip>=19.0.0,<20.0.0" && \
-    pip install setuptools virtualenv && \
-    rm -rf /root/.cache
+# Install rpmdevtools and epel-release
+RUN yum -y install rpmdevtools epel-release
+# Install python3
+RUN yum -y install python3 python3-devel python3-virtualenv  && \
+    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 # St2 package build debs
 RUN yum -y install \

--- a/buildpack/centos7/Dockerfile
+++ b/buildpack/centos7/Dockerfile
@@ -44,11 +44,66 @@ RUN yum -y install \
 
 # Install rpmdevtools and epel-release
 RUN yum -y install rpmdevtools epel-release
+RUN yum -y install python-devel && \
+    wget -qO - https://bootstrap.pypa.io/get-pip.py | python && \
+    pip install --upgrade "pip>=19.0.0,<20.0.0" && \
+    pip install setuptools virtualenv && \
+    rm -rf /root/.cache
+
 # Install python3
-RUN yum -y install python3 python3-devel python3-virtualenv  && \
-    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+#RUN pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+# Following 4 get past wheel errors but get pip errors
+#RUN yum -y install python3 python3-devel python3-virtualenv python3-wheel
+#RUN pip3 install --upgrade pip==19.1.1  && \
+#    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+#RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
+#
+# With above combination we fail early on the pip import veresion from the python setup.py bdist_wheel command
+#RUN yum -y install python3 python3-devel python3-virtualenv python3-wheel
+#RUN wget -qO get-pip.py https://bootstrap.pypa.io/get-pip.py
+#RUN python3 get-pip.py --force-reinstall && \
+#    pip3 install --upgrade pip==19.1.1 && \
+#    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
+#    rm -rf /root/.cache
+# If we take out virtualenv and wheel from python3 still have same problem...
+#RUN yum -y install python3 python3-devel
+#RUN wget -qO get-pip.py https://bootstrap.pypa.io/get-pip.py
+#RUN python3 get-pip.py --force-reinstall && \
+#    pip3 install --upgrade pip==19.1.1 && \
+#    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
+#    rm -rf /root/.cache
+#    Following fail on early import of pip on __version__ by python3 setup.py bdist_wheel
+#RUN yum -y install python3 python3-devel python3-virtualenv  python3-wheel
+#RUN python3 -m pip uninstall pip -y
+#RUN wget -qO - https://bootstrap.pypa.io/get-pip.py | python3 && \
+#    pip3 install --upgrade "pip>=19.0.0,<20.0.0" && \
+#    pip3 install --upgrade virtualenv==16.6.0 wheel && \
+#    pip3 install setuptools
+#RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
+## This combinations fails reallyl on with no comand bdist_wheel
+#RUN yum -y install python3 python3-devel python3-virtualenv  python3-wheel
+#RUN pip3 install --upgrade "pip==19.1.1" && \
+#    pip3 install --upgrade virtualenv==16.6.0 wheel && \
+#    pip3 install setuptools
+#RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
+#
+# Below combinations fails as gets past problems with initial wheel but then fails on pip internal
+# pip3 wheel --wheel-dir=/code/st2-rbac-backend/build/BUILDROOT/st2-rbac-backend-3.3dev-10.x86_64/opt/stackstorm/share/wheels -r requirements.txt -r test-requirements.txt
+# Traceback (most recent call last):
+#   File "/usr/local/bin/pip3", line 7, in <module>
+#       from pip._internal import main
+#       ModuleNotFoundError: No module named 'pip._internal'
+#       make[1]: Leaving directory `/code/st2-rbac-backend'
+RUN yum -y install python3 python3-devel python3-virtualenv  python3-wheel
+RUN pip3 install --upgrade "pip==19.1.1" && \
+    pip3 install --upgrade virtualenv==16.6.0 && \
+    pip3 install setuptools wheel
 RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
+
+
+# Install python3
+# Install python3
 
 # St2 package build debs
 RUN yum -y install \
-    openldap-devel
+   openldap-devel

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -121,19 +121,19 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 
 {% if (version == '8') -%}
 # Install development tools and python3 for EL8
-RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
+ RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
+     pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+ 
+ RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
+ 
+{%- elif version in ('7') -%}
+
+# Install rpmdevtools and epel-release
+RUN yum -y install rpmdevtools epel-release
+# Install python3
+RUN yum -y install python3 python3-devel python3-virtualenv  && \
     pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
 
-RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
-
-{%- elif version in ('7') -%}
-# Install development tools and python2 for EL <=7
-RUN yum -y install python2 python2-devel rpmdevtools
-
-# Install fresh pip and certs
-RUN curl https://bootstrap.pypa.io/get-pip.py | \
-    python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
-    pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 {%- endif %}
 
 {%- else -%}

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -77,13 +77,12 @@ RUN yum -y install nc net-tools
 #   - SSH access for build executor.
 #
 
-# Install development tools and python2 for EL <=7
-RUN yum -y install python2 python2-devel rpmdevtools
-
-# Install fresh pip and certs
-RUN curl https://bootstrap.pypa.io/get-pip.py | \
-    python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools && \
-    pip install --upgrade requests[security] venvctrl && rm -rf /root/.cache
+# Install rpmdevtools and epel-release
+RUN yum -y install rpmdevtools epel-release
+# Install python3
+RUN yum -y install python3 python3-devel python3-virtualenv  && \
+    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 VOLUME ["/home/busybee/build"]
 EXPOSE 22

--- a/packagingtest/Dockerfile.common
+++ b/packagingtest/Dockerfile.common
@@ -63,12 +63,12 @@ RUN yum -y install \
     openssl-devel \
     patch \
     postgresql-devel \
+    python3 \
     readline-devel \
     sqlite-devel \
     xz \
     xz-devel \
     zlib-devel {% if (version == '8') %}\
-    python3 \
     python3-virtualenv \
     python3-devel \
     openssl-devel \

--- a/packagingtest/centos7/systemd/Dockerfile
+++ b/packagingtest/centos7/systemd/Dockerfile
@@ -37,6 +37,7 @@ RUN yum -y install \
     openssl-devel \
     patch \
     postgresql-devel \
+    python3 \
     readline-devel \
     sqlite-devel \
     xz \


### PR DESCRIPTION
Update the EL7 docker containers to install python3, and pip3 and python3-virtualenv for building ST2 RPM.

Part of https://github.com/StackStorm/discussions/issues/54