### PR TITLE
Adding libldap2-dev libsasl2-dev dependencies for Ubuntu xenial and bionic

### DIFF
--- a/packagingbuild/bionic/Dockerfile
+++ b/packagingbuild/bionic/Dockerfile
@@ -44,8 +44,8 @@ RUN apt-get update && \
         python python-virtualenv \
         python3 python3-virtualenv python3-pip
 
-
-RUN apt-get -y install \
+RUN apt-get update && \
+    apt-get -y install \
         devscripts debhelper dh-make libldap2-dev libsasl2-dev && apt-get clean
 
 # Install fresh pip and co

--- a/packagingbuild/bionic/Dockerfile
+++ b/packagingbuild/bionic/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update && \
 
 
 RUN apt-get -y install \
-        devscripts debhelper dh-make && apt-get clean
+        devscripts debhelper dh-make libldap2-dev libsasl2-dev && apt-get clean
 
 # Install fresh pip and co
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -43,7 +43,8 @@ RUN apt-get update && \
     apt-get -y install build-essential python-dev python python-virtualenv
 
 
-RUN apt-get -y install \
+RUN apt-get update && \
+    apt-get -y install \
         devscripts debhelper dh-make libldap2-dev libsasl2-dev && apt-get clean
 
 # Install fresh pip and co

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update && \
 
 
 RUN apt-get -y install \
-        devscripts debhelper dh-make && apt-get clean
+        devscripts debhelper dh-make libldap2-dev libsasl2-dev && apt-get clean
 
 # Install fresh pip and co
 RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \


### PR DESCRIPTION
Part of https://github.com/StackStorm/st2-packages/pull/674 and https://github.com/StackStorm/st2/pull/5082

Building LDAP requires `libldap2-dev` and `libsasl2-dev` as a build dependencies.