### PR TITLE
Add python 3.6 PPA repository to Xenial packagingtest

### DIFF
--- a/buildpack/centos8/Dockerfile
+++ b/buildpack/centos8/Dockerfile
@@ -7,13 +7,13 @@ RUN yum -y install \
     wget
 
 RUN yum install -y yum-utils \
-    && dnf config-manager --enable PowerTools \
+    && dnf config-manager --enable powertools \
     && yum install -y epel-release \
     && yum -y install \
     ImageMagick \
     ImageMagick-devel \
     libyaml-devel \
-    && dnf config-manager --disable PowerTools \
+    && dnf config-manager --disable powertools \
     && yum remove -y epel-release yum-utils
 
 # Build tools

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -21,14 +21,14 @@ RUN yum -y install \
 
     {% if (version == '8') %}
 RUN yum install -y yum-utils \
-    && dnf config-manager --enable PowerTools \
+    && dnf config-manager --enable powertools \
     && yum install -y epel-release \
     && yum -y install \
     ImageMagick \
     ImageMagick-devel \
     libyaml-devel \
     glibc-langpack-en \
-    && dnf config-manager --disable PowerTools \
+    && dnf config-manager --disable powertools \
     && yum remove -y epel-release yum-utils
     {% endif %}
 

--- a/packagingbuild/centos8/Dockerfile
+++ b/packagingbuild/centos8/Dockerfile
@@ -13,14 +13,14 @@ RUN yum -y install \git \
 
     
 RUN yum install -y yum-utils \
-    && dnf config-manager --enable PowerTools \
+    && dnf config-manager --enable powertools \
     && yum install -y epel-release \
     && yum -y install \
     ImageMagick \
     ImageMagick-devel \
     libyaml-devel \
     glibc-langpack-en \
-    && dnf config-manager --disable PowerTools \
+    && dnf config-manager --disable powertools \
     && yum remove -y epel-release yum-utils
     
 

--- a/packagingtest/Dockerfile.common
+++ b/packagingtest/Dockerfile.common
@@ -21,7 +21,7 @@ RUN yum -y install \
     setup
     {% if (version == '8') %}
 RUN yum install -y yum-utils \
-    && dnf config-manager --enable PowerTools \
+    && dnf config-manager --enable powertools \
     && yum install -y epel-release \
     && yum -y install \
     ImageMagick \
@@ -29,7 +29,7 @@ RUN yum install -y yum-utils \
     libyaml-devel \
     libffi-devel \
     glibc-langpack-en \
-    && dnf config-manager --disable PowerTools \
+    && dnf config-manager --disable powertools \
     && yum remove -y epel-release yum-utils
     {% endif %}
 # Build tools

--- a/packagingtest/centos8/systemd/Dockerfile
+++ b/packagingtest/centos8/systemd/Dockerfile
@@ -14,7 +14,7 @@ RUN yum -y install \
     setup
     
 RUN yum install -y yum-utils \
-    && dnf config-manager --enable PowerTools \
+    && dnf config-manager --enable powertools \
     && yum install -y epel-release \
     && yum -y install \
     ImageMagick \
@@ -22,7 +22,7 @@ RUN yum install -y yum-utils \
     libyaml-devel \
     libffi-devel \
     glibc-langpack-en \
-    && dnf config-manager --disable PowerTools \
+    && dnf config-manager --disable powertools \
     && yum remove -y epel-release yum-utils
     
 # Build tools

--- a/packagingtest/xenial/systemd/Dockerfile
+++ b/packagingtest/xenial/systemd/Dockerfile
@@ -41,7 +41,11 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
     apt-get -y install gdebi-core sshpass cron netcat net-tools iproute
 
 # install apt https transport so apt sources can be added that refernece https:// URLs
-RUN apt-get -y install apt-transport-https ca-certificates
+RUN apt-get -y install apt-transport-https software-properties-common ca-certificates
+
+# Add python 3.6 repository from the 3rd party PPA as it's not available in base distro
+RUN add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get update
 
 # install netbase package (includes /etc/protocols and other files we rely on)
 RUN apt-get -y install netbase


### PR DESCRIPTION
Following the https://github.com/StackStorm/st2packaging-dockerfiles/pull/94 and https://github.com/StackStorm/st2-packages/pull/679, Ubuntu Xenial st2 packages relying on py3 are now built.

Next we'll need to add the py3 PPA repository to Xenial packagingtest as it's required for testing the st2.deb package installation.