### PR TITLE
Template re-sync and various other features and fixes

### DIFF
--- a/buildpack/bionic/Dockerfile
+++ b/buildpack/bionic/Dockerfile
@@ -6,7 +6,11 @@ RUN apt-get -y install build-essential python2.7-dev python2.7 python3-dev pytho
     rm -rf /root/.cache
 
 # Install fresh pip and co
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - \
+        pip==19.1.1 \
+        setuptools \
+        virtualenv==16.6.0 \
+        wheel; \
       pip3 install --upgrade requests[security] && rm -rf /root/.cache
 
 # Install debian build tools

--- a/buildpack/bionic/Dockerfile
+++ b/buildpack/bionic/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -y install build-essential python2.7-dev python2.7 python3-dev pytho
 
 # Install fresh pip and co
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - \
-        pip==19.1.1 \
+        pip==20.3.4 \
         setuptools \
         virtualenv==16.6.0 \
         wheel; \

--- a/buildpack/bionic/Dockerfile
+++ b/buildpack/bionic/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -y install build-essential python2.7-dev python2.7 python3-dev pytho
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - \
         pip==20.3.4 \
         setuptools \
-        virtualenv==16.6.0 \
+        virtualenv==20.2.2 \
         wheel; \
       pip3 install --upgrade requests[security] && rm -rf /root/.cache
 

--- a/buildpack/centos7/Dockerfile
+++ b/buildpack/centos7/Dockerfile
@@ -45,7 +45,7 @@ RUN yum -y install \
 # Python and tools
 RUN yum -y install python-devel && \
     wget -qO - https://bootstrap.pypa.io/get-pip.py | python && \
-    pip install --upgrade "pip>=19.0.0,<20.0.0" && \
+    pip install --upgrade pip==20.3.4 && \
     pip install setuptools && \
     pip install virtualenv && \
     rm -rf /root/.cache

--- a/buildpack/centos7/Dockerfile
+++ b/buildpack/centos7/Dockerfile
@@ -47,7 +47,7 @@ RUN yum -y install python-devel && \
     wget -qO - https://bootstrap.pypa.io/get-pip.py | python && \
     pip install --upgrade pip==20.3.4 && \
     pip install setuptools && \
-    pip install virtualenv && \
+    pip install --upgrade virtualenv==20.2.2 && \
     rm -rf /root/.cache
 
 # St2 package build debs

--- a/buildpack/centos7/Dockerfile
+++ b/buildpack/centos7/Dockerfile
@@ -46,7 +46,8 @@ RUN yum -y install \
 RUN yum -y install python-devel && \
     wget -qO - https://bootstrap.pypa.io/get-pip.py | python && \
     pip install --upgrade "pip>=19.0.0,<20.0.0" && \
-    pip install setuptools virtualenv && \
+    pip install setuptools && \
+    pip install virtualenv && \
     rm -rf /root/.cache
 
 # St2 package build debs

--- a/buildpack/centos8/Dockerfile
+++ b/buildpack/centos8/Dockerfile
@@ -54,7 +54,7 @@ RUN yum -y install \
 RUN yum -y install python3 python3-devel python3-wheel python3-virtualenv && \
     pip3 install --user --upgrade pip==20.3.4 && \
     pip3 install --user setuptools && \
-    pip3 install --user --upgrade virtualenv==16.6.0 \
+    pip3 install --user --upgrade virtualenv==20.2.2 \
     pip3 install --user wheel && \
     rm -rf /root/.cache
 

--- a/buildpack/centos8/Dockerfile
+++ b/buildpack/centos8/Dockerfile
@@ -52,7 +52,7 @@ RUN yum -y install \
 
 # Python and tools
 RUN yum -y install python3 python3-devel python3-wheel python3-virtualenv && \
-    pip3 install --user --upgrade pip==20.0.2 && \
+    pip3 install --user --upgrade pip==20.3.4 && \
     pip3 install --user setuptools && \
     pip3 install --user --upgrade virtualenv==16.6.0 \
     pip3 install --user wheel && \

--- a/buildpack/centos8/Dockerfile
+++ b/buildpack/centos8/Dockerfile
@@ -53,7 +53,9 @@ RUN yum -y install \
 # Python and tools
 RUN yum -y install python3 python3-devel python3-wheel python3-virtualenv && \
     pip3 install --user --upgrade pip==20.0.2 && \
-    pip3 install --user virtualenv==16.6.0 wheel setuptools  && \
+    pip3 install --user setuptools && \
+    pip3 install --user --upgrade virtualenv==16.6.0 \
+    pip3 install --user wheel && \
     rm -rf /root/.cache
 
 # St2 package build debs

--- a/packagingbuild/Dockerfile.debian
+++ b/packagingbuild/Dockerfile.debian
@@ -21,7 +21,7 @@ RUN apt-get update && \
 # Install fresh pip and co
 {% if version in ('bionic') -%}
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - \
-        pip==19.1.1 \
+        pip==20.3.4 \
         setuptools \
         virtualenv==16.6.0 \
         wheel \
@@ -29,7 +29,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - \
       pip3 install --upgrade requests[security] && rm -rf /root/.cache
 {%- else -%}
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6 - \
-        pip==19.1.1 \
+        pip==20.3.4 \
         setuptools \
         virtualenv==16.6.0 \
         wheel ; \

--- a/packagingbuild/Dockerfile.debian
+++ b/packagingbuild/Dockerfile.debian
@@ -23,7 +23,7 @@ RUN apt-get update && \
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - \
         pip==20.3.4 \
         setuptools \
-        virtualenv==16.6.0 \
+        virtualenv==20.2.2 \
         wheel \
         cryptography; \
       pip3 install --upgrade requests[security] && rm -rf /root/.cache
@@ -31,7 +31,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - \
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6 - \
         pip==20.3.4 \
         setuptools \
-        virtualenv==16.6.0 \
+        virtualenv==20.2.2 \
         wheel ; \
       pip3.6 install --upgrade requests[security] && rm -rf /root/.cache
 {%- endif %}

--- a/packagingbuild/Dockerfile.debian
+++ b/packagingbuild/Dockerfile.debian
@@ -20,10 +20,19 @@ RUN apt-get update && \
 
 # Install fresh pip and co
 {% if version in ('bionic') -%}
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools cryptography; \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - \
+        pip==19.1.1 \
+        setuptools \
+        virtualenv==16.6.0 \
+        wheel \
+        cryptography; \
       pip3 install --upgrade requests[security] && rm -rf /root/.cache
 {%- else -%}
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6 - \
+        pip==19.1.1 \
+        setuptools \
+        virtualenv==16.6.0 \
+        wheel ; \
       pip3.6 install --upgrade requests[security] && rm -rf /root/.cache
 {%- endif %}
 

--- a/packagingbuild/Dockerfile.debian
+++ b/packagingbuild/Dockerfile.debian
@@ -1,31 +1,36 @@
 
-# install python development
+{% if version in ('xenial') %}
+# Install python 3.6 & development
+# from the PPA as it's not available in base distro
+RUN add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get -y install build-essential python3.6-dev python3.6
+{% endif %}
+
 {% if version in ('bionic') -%}
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+# install python development
+RUN apt-get update && \
     apt-get -y install build-essential \
         python python-virtualenv \
         python3 python3-virtualenv python3-pip
-{%- else -%}
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get -y install build-essential python-dev python python-virtualenv
 {%- endif %}
 
-
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
-        devscripts debhelper dh-make && apt-get clean
+RUN apt-get update && \
+    apt-get -y install \
+        devscripts debhelper dh-make libldap2-dev libsasl2-dev && apt-get clean
 
 # Install fresh pip and co
 {% if version in ('bionic') -%}
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools cryptography; \
       pip3 install --upgrade requests[security] && rm -rf /root/.cache
 {%- else -%}
-RUN curl https://bootstrap.pypa.io/get-pip.py | python - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
-      pip install --upgrade requests[security] && rm -rf /root/.cache
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
+      pip3.6 install --upgrade requests[security] && rm -rf /root/.cache
 {%- endif %}
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
-        python-setuptools python-mock && \
+RUN apt-get -y install \
+        {% if version in ('xenial') %}python-virtualenv {% endif %}python-setuptools python-mock && \
         apt-get clean && \
         git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \
@@ -33,5 +38,5 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
           rm -rf /tmp/dh-virtualenv*
 
 {%- if version in ('xenial', 'bionic') %}
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install dh-systemd && apt-get clean
+RUN apt-get -y install dh-systemd && apt-get clean
 {%- endif -%}

--- a/packagingbuild/Dockerfile.debian
+++ b/packagingbuild/Dockerfile.debian
@@ -11,7 +11,6 @@ RUN add-apt-repository -y ppa:deadsnakes/ppa && \
 # install python development
 RUN apt-get update && \
     apt-get -y install build-essential \
-        python python-virtualenv \
         python3 python3-virtualenv python3-pip
 {%- endif %}
 
@@ -30,7 +29,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6 - virtualenv==16.6.0 p
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites
 RUN apt-get -y install \
-        {% if version in ('xenial') %}python-virtualenv {% endif %}python-setuptools python-mock && \
+        python-virtualenv python-setuptools python-mock && \
         apt-get clean && \
         git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -131,7 +131,7 @@ RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
     pip3 install \
         pip==20.3.4 \
         setuptools \
-        virtualenv==16.6.0 \
+        virtualenv==20.2.2 \
         wheel
 {%- elif version in ('7') -%}
 
@@ -142,7 +142,7 @@ RUN yum -y install python3 python3-devel python3-virtualenv  && \
     pip3 install \
         pip==20.3.4 \
         setuptools \
-        virtualenv==16.6.0 \
+        virtualenv==20.2.2 \
         wheel
 {%- endif %}
 RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -129,7 +129,7 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 # Install development tools and python3 for EL8
 RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
     pip3 install \
-        pip==19.1.1 \
+        pip==20.3.4 \
         setuptools \
         virtualenv==16.6.0 \
         wheel
@@ -140,7 +140,7 @@ RUN yum -y install rpmdevtools epel-release
 # Install python3
 RUN yum -y install python3 python3-devel python3-virtualenv  && \
     pip3 install \
-        pip==19.1.1 \
+        pip==20.3.4 \
         setuptools \
         virtualenv==16.6.0 \
         wheel

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -129,9 +129,6 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 # Install development tools and python3 for EL8
 RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
     pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
-
-RUN pip3 install requests[security] venvctrl --upgrade && rm -rf /root/.cache
-
 {%- elif version in ('7') -%}
 
 # Install rpmdevtools and epel-release
@@ -139,19 +136,14 @@ RUN yum -y install rpmdevtools epel-release
 # Install python3
 RUN yum -y install python3 python3-devel python3-virtualenv  && \
     pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+{%- endif %}
 RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
-
-{%- endif -%}
 
 {%- else -%}
 {%- include "Dockerfile.debian" -%}
 {%- endif %}
 
-{% if dist in ('centos', 'fedora') -%}
 VOLUME ["/home/busybee/build"]
-{%- else -%}
-VOLUME ['/home/busybee/build']
-{%- endif %}
 EXPOSE 22
 
 # Run ssh daemon in foreground and wait for bees to connect.

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -128,14 +128,22 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 {% if (version == '8') -%}
 # Install development tools and python3 for EL8
 RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
-    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+    pip3 install \
+        pip==19.1.1 \
+        setuptools \
+        virtualenv==16.6.0 \
+        wheel
 {%- elif version in ('7') -%}
 
 # Install rpmdevtools and epel-release
 RUN yum -y install rpmdevtools epel-release
 # Install python3
 RUN yum -y install python3 python3-devel python3-virtualenv  && \
-    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+    pip3 install \
+        pip==19.1.1 \
+        setuptools \
+        virtualenv==16.6.0 \
+        wheel
 {%- endif %}
 RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 

--- a/packagingbuild/Dockerfile.template
+++ b/packagingbuild/Dockerfile.template
@@ -13,13 +13,13 @@ RUN yum -y install \
     wget
 
 RUN yum -y install \
-    {%- if (version == '7') -%}bzr \{%- endif -%}
+{%- if (version == '7') -%}    bzr \{%- endif -%}
     git \
     mercurial \
     openssh \
     subversion
 
-    {% if (version == '8') %}
+{% if (version == '8') %}
 RUN yum install -y yum-utils \
     && dnf config-manager --enable powertools \
     && yum install -y epel-release \
@@ -30,7 +30,7 @@ RUN yum install -y yum-utils \
     glibc-langpack-en \
     && dnf config-manager --disable powertools \
     && yum remove -y epel-release yum-utils
-    {% endif %}
+{% endif %}
 
 # Build tools
 RUN yum -y install \
@@ -75,6 +75,12 @@ RUN yum -y install \
     openldap-devel
 {%- endif %}
 
+{% if version in ('xenial', 'bionic') -%}
+# Make noninteractive setting permanent
+ENV DEBIAN_FRONTEND noninteractive
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections -v
+{%- endif %}
+
 # Enable remote pubkey access
 RUN mkdir /root/.ssh && chmod 700 /root/.ssh && \
     echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCdCmmPjsOBWRXc+PKdgDRrsciNjp25zTacyz8Gdkln2ma046brOYXAphhp/85DKgHtANBBt3cl4+HnpDbmAfyq2qZT7hWzAbMxtq0Sj+yyFyUdreXoe4gEKyxpV6o8p/R/XzEcawvqX/vFc5EIFmvTdamxZs9DQmOE5AZMzUB18Kerkrb0/arUcZ8iMi9Ng9a18avow+7oUFZ6Oub7ISz/dkIRojaKO/2paJZ4p+v7ZLn7Hq8TUeBkgAlx872oh8J8linhIq17zK6x4MGL8qiurp2hnfe0cuCxwcsYGy+4DfK51+E2vks6FprCIfF5hIdz26euPn67/YpM0F0b5nXF busybee@drone" >> /root/.ssh/authorized_keys
@@ -87,7 +93,7 @@ RUN chmod 600 /root/.ssh/busybee
 RUN yum -y install openssh-server sudo && \
   ssh-keygen -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key
 {%- else -%}
-RUN DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
+RUN apt-get -y update && \
     apt-get install -y openssh-server sudo && \
     mkdir /var/run/sshd
 {%- endif %}
@@ -106,9 +112,9 @@ RUN yum -y install nc net-tools
 {%- else -%}
 # install core software for packaging and ssh communication
 RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
-    DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
+    apt-get -y update && \
     apt-get -y install gdebi-core sshpass cron \
-      netcat net-tools
+      netcat net-tools{% if version in ('xenial') %} software-properties-common{% endif %}
 {%- endif %}
 
 #
@@ -117,15 +123,15 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 #   - SSH access for build executor.
 #
 
-{%- if dist in ('centos', 'fedora') -%}
+{%- if dist in ('centos', 'fedora') %}
 
 {% if (version == '8') -%}
 # Install development tools and python3 for EL8
- RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
-     pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
- 
- RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
- 
+RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
+    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+
+RUN pip3 install requests[security] venvctrl --upgrade && rm -rf /root/.cache
+
 {%- elif version in ('7') -%}
 
 # Install rpmdevtools and epel-release
@@ -133,14 +139,19 @@ RUN yum -y install rpmdevtools epel-release
 # Install python3
 RUN yum -y install python3 python3-devel python3-virtualenv  && \
     pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
-{%- endif %}
+{%- endif -%}
 
 {%- else -%}
-{% include "Dockerfile.debian" -%}
+{%- include "Dockerfile.debian" -%}
 {%- endif %}
 
+{% if dist in ('centos', 'fedora') -%}
 VOLUME ["/home/busybee/build"]
+{%- else -%}
+VOLUME ['/home/busybee/build']
+{%- endif %}
 EXPOSE 22
 
 # Run ssh daemon in foreground and wait for bees to connect.

--- a/packagingbuild/README.md
+++ b/packagingbuild/README.md
@@ -6,8 +6,6 @@ Docker images used to build `.deb` and `.rpm` StackStorm packages in [StackStorm
 In these containers build environment specific for each OS distro is pre-installed and respective StackStorm packages are built for each platform.
 
 [`Dockerfiles` sources](https://github.com/StackStorm/st2packaging-dockerfiles/blob/master/packagingbuild):
-- Debian Wheezy
-- Debian Jessie
 - CentOS 7
 - CentOS 8
 - Ubuntu Xenial

--- a/packagingbuild/bionic/Dockerfile
+++ b/packagingbuild/bionic/Dockerfile
@@ -48,7 +48,12 @@ RUN apt-get update && \
         devscripts debhelper dh-make libldap2-dev libsasl2-dev && apt-get clean
 
 # Install fresh pip and co
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools cryptography; \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - \
+        pip==19.1.1 \
+        setuptools \
+        virtualenv==16.6.0 \
+        wheel \
+        cryptography; \
       pip3 install --upgrade requests[security] && rm -rf /root/.cache
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites

--- a/packagingbuild/bionic/Dockerfile
+++ b/packagingbuild/bionic/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update && \
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - \
         pip==20.3.4 \
         setuptools \
-        virtualenv==16.6.0 \
+        virtualenv==20.2.2 \
         wheel \
         cryptography; \
       pip3 install --upgrade requests[security] && rm -rf /root/.cache

--- a/packagingbuild/bionic/Dockerfile
+++ b/packagingbuild/bionic/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update && \
 
 # Install fresh pip and co
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - \
-        pip==19.1.1 \
+        pip==20.3.4 \
         setuptools \
         virtualenv==16.6.0 \
         wheel \

--- a/packagingbuild/bionic/Dockerfile
+++ b/packagingbuild/bionic/Dockerfile
@@ -41,7 +41,6 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 # install python development
 RUN apt-get update && \
     apt-get -y install build-essential \
-        python python-virtualenv \
         python3 python3-virtualenv python3-pip
 
 RUN apt-get update && \
@@ -54,7 +53,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites
 RUN apt-get -y install \
-        python-setuptools python-mock && \
+        python-virtualenv python-setuptools python-mock && \
         apt-get clean && \
         git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \
@@ -62,7 +61,7 @@ RUN apt-get -y install \
           rm -rf /tmp/dh-virtualenv*
 RUN apt-get -y install dh-systemd && apt-get clean
 
-VOLUME ['/home/busybee/build']
+VOLUME ["/home/busybee/build"]
 EXPOSE 22
 
 # Run ssh daemon in foreground and wait for bees to connect.

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -83,7 +83,11 @@ RUN yum -y install nc net-tools
 RUN yum -y install rpmdevtools epel-release
 # Install python3
 RUN yum -y install python3 python3-devel python3-virtualenv  && \
-    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+    pip3 install \
+        pip==19.1.1 \
+        setuptools \
+        virtualenv==16.6.0 \
+        wheel
 RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 VOLUME ["/home/busybee/build"]

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -86,7 +86,7 @@ RUN yum -y install python3 python3-devel python3-virtualenv  && \
     pip3 install \
         pip==20.3.4 \
         setuptools \
-        virtualenv==16.6.0 \
+        virtualenv==20.2.2 \
         wheel
 RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -11,7 +11,7 @@ RUN yum -y install \bzr \git \
     openssh \
     subversion
 
-    
+
 
 # Build tools
 RUN yum -y install \
@@ -48,6 +48,8 @@ RUN yum -y install \
 # St2 package build debs
 RUN yum -y install \
     openldap-devel
+
+
 
 # Enable remote pubkey access
 RUN mkdir /root/.ssh && chmod 700 /root/.ssh && \

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -84,7 +84,7 @@ RUN yum -y install rpmdevtools epel-release
 # Install python3
 RUN yum -y install python3 python3-devel python3-virtualenv  && \
     pip3 install \
-        pip==19.1.1 \
+        pip==20.3.4 \
         setuptools \
         virtualenv==16.6.0 \
         wheel

--- a/packagingbuild/centos8/Dockerfile
+++ b/packagingbuild/centos8/Dockerfile
@@ -11,7 +11,7 @@ RUN yum -y install \git \
     openssh \
     subversion
 
-    
+
 RUN yum install -y yum-utils \
     && dnf config-manager --enable powertools \
     && yum install -y epel-release \
@@ -22,7 +22,7 @@ RUN yum install -y yum-utils \
     glibc-langpack-en \
     && dnf config-manager --disable powertools \
     && yum remove -y epel-release yum-utils
-    
+
 
 # Build tools
 RUN yum -y install \
@@ -58,6 +58,8 @@ RUN yum -y install \
 # St2 package build debs
 RUN yum -y install \
     openldap-devel
+
+
 
 # Enable remote pubkey access
 RUN mkdir /root/.ssh && chmod 700 /root/.ssh && \

--- a/packagingbuild/centos8/Dockerfile
+++ b/packagingbuild/centos8/Dockerfile
@@ -91,7 +91,11 @@ RUN yum -y install nc net-tools
 
 # Install development tools and python3 for EL8
 RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
-    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+    pip3 install \
+        pip==19.1.1 \
+        setuptools \
+        virtualenv==16.6.0 \
+        wheel
 RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 VOLUME ["/home/busybee/build"]

--- a/packagingbuild/centos8/Dockerfile
+++ b/packagingbuild/centos8/Dockerfile
@@ -94,7 +94,7 @@ RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
     pip3 install \
         pip==20.3.4 \
         setuptools \
-        virtualenv==16.6.0 \
+        virtualenv==20.2.2 \
         wheel
 RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 

--- a/packagingbuild/centos8/Dockerfile
+++ b/packagingbuild/centos8/Dockerfile
@@ -92,8 +92,7 @@ RUN yum -y install nc net-tools
 # Install development tools and python3 for EL8
 RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
     pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
-
-RUN pip3 install requests[security] venvctrl --upgrade && rm -rf /root/.cache
+RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 VOLUME ["/home/busybee/build"]
 EXPOSE 22

--- a/packagingbuild/centos8/Dockerfile
+++ b/packagingbuild/centos8/Dockerfile
@@ -92,7 +92,7 @@ RUN yum -y install nc net-tools
 # Install development tools and python3 for EL8
 RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
     pip3 install \
-        pip==19.1.1 \
+        pip==20.3.4 \
         setuptools \
         virtualenv==16.6.0 \
         wheel

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -51,7 +51,11 @@ RUN apt-get update && \
         devscripts debhelper dh-make libldap2-dev libsasl2-dev && apt-get clean
 
 # Install fresh pip and co
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6 - \
+        pip==19.1.1 \
+        setuptools \
+        virtualenv==16.6.0 \
+        wheel ; \
       pip3.6 install --upgrade requests[security] && rm -rf /root/.cache
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get -y install \
           rm -rf /tmp/dh-virtualenv*
 RUN apt-get -y install dh-systemd && apt-get clean
 
-VOLUME ['/home/busybee/build']
+VOLUME ["/home/busybee/build"]
 EXPOSE 22
 
 # Run ssh daemon in foreground and wait for bees to connect.

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update && \
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6 - \
         pip==20.3.4 \
         setuptools \
-        virtualenv==16.6.0 \
+        virtualenv==20.2.2 \
         wheel ; \
       pip3.6 install --upgrade requests[security] && rm -rf /root/.cache
 

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -37,12 +37,13 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 #   - SSH access for build executor.
 #
 
-
 # Install python 3.6 & development
 # from the PPA as it's not available in base distro
 RUN add-apt-repository -y ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get -y install build-essential python3.6-dev python3.6
+
+
 
 
 RUN apt-get update && \

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update && \
 
 # Install fresh pip and co
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6 - \
-        pip==19.1.1 \
+        pip==20.3.4 \
         setuptools \
         virtualenv==16.6.0 \
         wheel ; \

--- a/packagingtest/Dockerfile.common
+++ b/packagingtest/Dockerfile.common
@@ -13,13 +13,13 @@ RUN yum -y install \
     wget
 
 RUN yum -y install \
-    {% if (version == '7') -%}bzr \{% endif -%}
-    git \
+{% if (version == '7') %}    bzr \
+{% endif %}    git \
     mercurial \
     openssh \
     subversion \
     setup
-    {% if (version == '8') %}
+{% if (version == '8') %}
 RUN yum install -y yum-utils \
     && dnf config-manager --enable powertools \
     && yum install -y epel-release \
@@ -27,11 +27,10 @@ RUN yum install -y yum-utils \
     ImageMagick \
     ImageMagick-devel \
     libyaml-devel \
-    libffi-devel \
     glibc-langpack-en \
     && dnf config-manager --disable powertools \
     && yum remove -y epel-release yum-utils
-    {% endif %}
+{% endif %}
 # Build tools
 RUN yum -y install \
     autoconf \
@@ -43,18 +42,19 @@ RUN yum -y install \
     gcc-c++ \
     glib2-devel \
     glibc-devel \
-    {%- if (version == '7') -%}
+    {%- if (version == '7') %}
     ImageMagick \
     ImageMagick-devel \
     {%- endif %}
     libcurl-devel \
     libevent-devel \
+    libffi-devel \
     libjpeg-devel \
     libtool \
     libwebp-devel \
     libxml2-devel \
     libxslt-devel \
-    {%- if (version == '7') -%}
+    {%- if (version == '7') %}
     libyaml-devel \
     {%- endif %}
     make \
@@ -68,7 +68,7 @@ RUN yum -y install \
     sqlite-devel \
     xz \
     xz-devel \
-    zlib-devel {% if (version == '8') %}\
+    zlib-devel{% if (version == '8') %} \
     python3-virtualenv \
     python3-devel \
     openssl-devel \
@@ -79,11 +79,20 @@ RUN yum -y install \
     zip \
     unzip{%- endif %}
 
-
-
 # St2 package build debs
 RUN yum -y install \
     openldap-devel
+{% else %}
+
+ENV container docker
+ENV TERM xterm
+
+# Make noninteractive setting permanent
+ENV DEBIAN_FRONTEND noninteractive
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections -v
+
+RUN apt-get -y update
+
 {%- endif %}
 
 # Enable remote pubkey access
@@ -97,11 +106,16 @@ RUN chmod 600 /root/.ssh/busybee
 {% if dist in ('centos', 'fedora') -%}
 RUN yum -y install openssh-server sudo && \
   ssh-keygen -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key
-{%- else %}
-
-RUN DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
-    apt-get install -y openssh-server sudo && \
+{%- else -%}
+RUN apt-get install -y openssh-server sudo && \
     mkdir /var/run/sshd
+
+# install locales package and set default locale to 'UTF-8' for the test execution environment
+RUN apt-get -y install locales && \
+    locale-gen en_US.UTF-8 && \
+    dpkg-reconfigure locales && \
+    update-locale LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
 {%- endif %}
 
 # 1. small fix for SSH in ubuntu 13.10 (that's harmless everywhere else)
@@ -122,11 +136,19 @@ RUN yum -y install nc net-tools {%- if (version == '8') %} glibc-locale-source &
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-    {% endif%}
+{% endif%}
 {% else -%}
 # install core software for packaging and ssh communication
 RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
-    DEBIAN_FRONTEND=noninteractive && apt-get -y update && \
-    apt-get -y install gdebi-core sshpass cron \
-      netcat net-tools
+    apt-get -y install gdebi-core sshpass cron netcat net-tools iproute
+
+# install apt https transport so apt sources can be added that refernece https:// URLs
+RUN apt-get -y install apt-transport-https software-properties-common ca-certificates
+
+# Add python 3.6 repository from the 3rd party PPA as it's not available in base distro
+RUN add-apt-repository -y ppa:deadsnakes/ppa && \
+    apt-get update
+
+# install netbase package (includes /etc/protocols and other files we rely on)
+RUN apt-get -y install netbase
 {% endif %}

--- a/packagingtest/Dockerfile.template-systemd
+++ b/packagingtest/Dockerfile.template-systemd
@@ -4,9 +4,9 @@
 ENV container docker
 
 RUN yum -y update; \
-    yum -y install systemd; yum clean all
+    yum -y install systemd; yum clean all;
 
-RUN cd /lib/systemd/system/sysinit.target.wants/; ls -1 | grep -v systemd-tmpfiles-setup.service | xargs rm; \ 
+RUN cd /lib/systemd/system/sysinit.target.wants/; ls -1 | grep -v systemd-tmpfiles-setup.service | xargs rm; \
     rm -f /etc/systemd/system/*.wants/*;\
     rm -f /lib/systemd/system/local-fs.target.wants/*; \
     rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
@@ -15,14 +15,19 @@ RUN cd /lib/systemd/system/sysinit.target.wants/; ls -1 | grep -v systemd-tmpfil
     rm -f /lib/systemd/system/anaconda.target.wants/*;\
     systemctl preset sshd;
 
+{% if version in ('centos7') or version in ('centos8') -%}
+# install doc files (/usr/share/docs) when installing yum packages
+# otherwise /usr/share/docs/st2/conf/nginx/st2.conf won't be present
+# https://github.com/docker-library/docs/tree/master/centos#package-documentation
+RUN sed -i '/nodocs/d' /etc/yum.conf
+{%- endif %}
+
 # we can have ssh
 EXPOSE 22
 
 VOLUME [ "/sys/fs/cgroup" ]
 CMD [ "/usr/sbin/init" ]
-{%- elif version in ('xenial') -%}
-ENV container docker
-
+{%- elif version in ('xenial') %}
 RUN find /etc/systemd/system \
          /lib/systemd/system \
          -path '*.wants/*' \
@@ -33,7 +38,7 @@ RUN find /etc/systemd/system \
 
 RUN systemctl set-default multi-user.target
 
-COPY setup /sbin/
+COPY setup.sh /sbin/
 
 RUN systemctl preset ssh;
 

--- a/packagingtest/centos7/systemd/Dockerfile
+++ b/packagingtest/centos7/systemd/Dockerfile
@@ -7,12 +7,13 @@ RUN yum -y install \
     wget
 
 RUN yum -y install \
-    bzr \git \
+    bzr \
+    git \
     mercurial \
     openssh \
     subversion \
     setup
-    
+
 # Build tools
 RUN yum -y install \
     autoconf \
@@ -23,15 +24,19 @@ RUN yum -y install \
     gcc \
     gcc-c++ \
     glib2-devel \
-    glibc-devel \ImageMagick \
-    ImageMagick-devel \libcurl-devel \
+    glibc-devel \
+    ImageMagick \
+    ImageMagick-devel \
+    libcurl-devel \
     libevent-devel \
     libffi-devel \
     libjpeg-devel \
     libtool \
     libwebp-devel \
     libxml2-devel \
-    libxslt-devel \libyaml-devel \make \
+    libxslt-devel \
+    libyaml-devel \
+    make \
     mysql-devel \
     ncurses-devel \
     openssl-devel \
@@ -47,6 +52,7 @@ RUN yum -y install \
 # St2 package build debs
 RUN yum -y install \
     openldap-devel
+
 
 # Enable remote pubkey access
 RUN mkdir /root/.ssh && chmod 700 /root/.ssh && \
@@ -69,7 +75,6 @@ RUN sed -ri 's/^session\s+required\s+pam_loginuid.so$/session optional pam_login
         echo 'root:docker.io' | chpasswd
 
 RUN yum -y install nc net-tools
-
 ENV container docker
 
 RUN yum -y update; \

--- a/packagingtest/centos8/systemd/Dockerfile
+++ b/packagingtest/centos8/systemd/Dockerfile
@@ -12,7 +12,7 @@ RUN yum -y install \
     openssh \
     subversion \
     setup
-    
+
 RUN yum install -y yum-utils \
     && dnf config-manager --enable powertools \
     && yum install -y epel-release \
@@ -20,11 +20,10 @@ RUN yum install -y yum-utils \
     ImageMagick \
     ImageMagick-devel \
     libyaml-devel \
-    libffi-devel \
     glibc-langpack-en \
     && dnf config-manager --disable powertools \
     && yum remove -y epel-release yum-utils
-    
+
 # Build tools
 RUN yum -y install \
     autoconf \
@@ -38,6 +37,7 @@ RUN yum -y install \
     glibc-devel \
     libcurl-devel \
     libevent-devel \
+    libffi-devel \
     libjpeg-devel \
     libtool \
     libwebp-devel \
@@ -49,12 +49,12 @@ RUN yum -y install \
     openssl-devel \
     patch \
     postgresql-devel \
+    python3 \
     readline-devel \
     sqlite-devel \
     xz \
     xz-devel \
     zlib-devel \
-    python3 \
     python3-virtualenv \
     python3-devel \
     openssl-devel \
@@ -65,11 +65,10 @@ RUN yum -y install \
     zip \
     unzip
 
-
-
 # St2 package build debs
 RUN yum -y install \
     openldap-devel
+
 
 # Enable remote pubkey access
 RUN mkdir /root/.ssh && chmod 700 /root/.ssh && \
@@ -99,11 +98,11 @@ RUN yum -y install nc net-tools glibc-locale-source && \
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-    
+
 ENV container docker
 
 RUN yum -y update; \
-    yum -y install systemd; yum clean all
+    yum -y install systemd; yum clean all;
 
 RUN cd /lib/systemd/system/sysinit.target.wants/; ls -1 | grep -v systemd-tmpfiles-setup.service | xargs rm; \
     rm -f /etc/systemd/system/*.wants/*;\

--- a/update.py
+++ b/update.py
@@ -52,7 +52,7 @@ def match_and_fetch(value, item_or_hash):
 
     item = item_or_hash
     if isinstance(item, dict):
-        item, match_list = item.items()[0]
+        item, match_list = list(item.items())[0]
     else:
         match_list = [value]
 


### PR DESCRIPTION
I'll rebase this off of #98 once everything is up and working.

This PR corrects some of the "development drift" that has happened from people modifying Dockerfiles directly instead of modifying the Dockerfile templates and running `update.py`, and changes the Dockerfile templates to generate the content of the various Dockerfiles.

I have some very small improvements to the `update.py` script locally that I'm trying to wrap up, as well as adding a `Makefile` with targets to:

* automagically create a virtualenv
* install requirements
* run `update.py`
* check that the Dockerfile templates and the Dockerfiles were all updated together

And I'd like to integrate that into a CI test for this repo to ensure that the Dockerfile templates and the Dockerfiles themselves are always in sync.