### PR TITLE
Pin pip to 20.0.2 which is the same version used in StackStorm/st2 repo (support for manylinux2014 wheel format)

### DIFF
--- a/packagingbuild/bionic/Dockerfile
+++ b/packagingbuild/bionic/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update && \
         devscripts debhelper dh-make libldap2-dev libsasl2-dev && apt-get clean
 
 # Install fresh pip and co
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools cryptography; \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip==20.0.2 wheel setuptools cryptography; \
       pip3 install --upgrade requests[security] && rm -rf /root/.cache
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites

--- a/packagingbuild/centos7/Dockerfile
+++ b/packagingbuild/centos7/Dockerfile
@@ -79,7 +79,7 @@ RUN yum -y install nc net-tools
 RUN yum -y install rpmdevtools epel-release
 # Install python3
 RUN yum -y install python3 python3-devel python3-virtualenv  && \
-    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+    pip3 install virtualenv==16.6.0 pip==20.0.2 wheel setuptools
 RUN pip3 install --upgrade requests[security] venvctrl && rm -rf /root/.cache
 
 VOLUME ["/home/busybee/build"]

--- a/packagingbuild/centos8/Dockerfile
+++ b/packagingbuild/centos8/Dockerfile
@@ -87,7 +87,7 @@ RUN yum -y install nc net-tools
 
 # Install development tools and python3 for EL8
 RUN yum -y install python3 python3-devel rpmdevtools python3-virtualenv && \
-    pip3 install virtualenv==16.6.0 pip==19.1.1 wheel setuptools
+    pip3 install virtualenv==16.6.0 pip==20.0.2 wheel setuptools
 
 RUN pip3 install requests[security] venvctrl --upgrade && rm -rf /root/.cache
 

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update && \
         devscripts debhelper dh-make libldap2-dev libsasl2-dev && apt-get clean
 
 # Install fresh pip and co
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6 - virtualenv==16.6.0 pip==19.1.1 wheel setuptools; \
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6 - virtualenv==16.6.0 pip==20.0.2 wheel setuptools; \
       pip3.6 install --upgrade requests[security] && rm -rf /root/.cache
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites


### PR DESCRIPTION
This pull request pins pip to ``20.0.2`` which is the same version used in StackStorm/st2 repo.

In https://github.com/StackStorm/st2/pull/5153 I added ``orjson`` dependency which utilizes manywheel2014 format which is only supported by pip >= 19.3.

If older version of pip is used, it will try to build dependency from scratch and fail since build tools are not available.

If for some reason we can't use 20.x, using 19.3 should also work for that specific issue.