### PR TITLE
Fix bionicbuild image so we don't bundle two different pip version

### DIFF
--- a/packagingbuild/bionic/Dockerfile
+++ b/packagingbuild/bionic/Dockerfile
@@ -48,14 +48,14 @@ RUN apt-get update && \
         devscripts debhelper dh-make libldap2-dev libsasl2-dev && apt-get clean
 
 # Install fresh pip and co
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip==20.0.2 wheel setuptools cryptography; \
-      pip3 install --upgrade requests[security] && rm -rf /root/.cache
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6 - virtualenv==16.6.0 pip==20.0.2 wheel setuptools cryptography; \
+      pip3.6 install --upgrade requests[security] && rm -rf /root/.cache
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites
 RUN apt-get -y install \
         python-virtualenv python-setuptools python-mock && \
         apt-get clean && \
-        git clone --branch rm_site_packages_flag https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
+        git clone --branch stackstorm_patched_use_custom_pip https://github.com/StackStorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \
         dpkg-buildpackage -b -uc -us && dpkg -i ../dh-virtualenv_*.deb && \
           rm -rf /tmp/dh-virtualenv*

--- a/packagingbuild/bionic/Dockerfile
+++ b/packagingbuild/bionic/Dockerfile
@@ -37,7 +37,6 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 #   - SSH access for build executor.
 #
 
-
 # install python development
 RUN apt-get update && \
     apt-get -y install build-essential \

--- a/packagingbuild/bionic/Dockerfile
+++ b/packagingbuild/bionic/Dockerfile
@@ -41,7 +41,7 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 # install python development
 RUN apt-get update && \
     apt-get -y install build-essential \
-        python3
+        python3-dev python3
 
 RUN apt-get update && \
     apt-get -y install \

--- a/packagingbuild/bionic/Dockerfile
+++ b/packagingbuild/bionic/Dockerfile
@@ -55,7 +55,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip
 RUN apt-get -y install \
         python-virtualenv python-setuptools python-mock && \
         apt-get clean && \
-        git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
+        git clone --branch rm_site_packages_flag https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \
         dpkg-buildpackage -b -uc -us && dpkg -i ../dh-virtualenv_*.deb && \
           rm -rf /tmp/dh-virtualenv*

--- a/packagingbuild/bionic/Dockerfile
+++ b/packagingbuild/bionic/Dockerfile
@@ -41,8 +41,7 @@ RUN echo -e "#!/bin/sh\nexit 101\n" > /usr/sbin/policy-rc.d && \
 # install python development
 RUN apt-get update && \
     apt-get -y install build-essential \
-        python python-virtualenv \
-        python3 python3-virtualenv python3-pip
+        python3
 
 RUN apt-get update && \
     apt-get -y install \
@@ -54,7 +53,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3 - virtualenv==16.6.0 pip
 
 # We use our dh-virtualenv version, since it fixes shebangd lines rewrites
 RUN apt-get -y install \
-        python-setuptools python-mock && \
+        python-virtualenv python-setuptools python-mock && \
         apt-get clean && \
         git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -12,6 +12,9 @@ RUN mkdir /root/.ssh && chmod 700 /root/.ssh && \
 COPY busybee*  /root/.ssh/
 RUN chmod 600 /root/.ssh/busybee
 
+# Temporary workaround to work around failing apt mirror for half a day already
+RUN sed -i "s#deb.debian.org#ftp.si.debian.org#g" /etc/apt/sources.list
+
 RUN apt-get -y update && \
     apt-get install -y openssh-server sudo && \
     mkdir /var/run/sshd

--- a/packagingbuild/xenial/Dockerfile
+++ b/packagingbuild/xenial/Dockerfile
@@ -57,7 +57,7 @@ RUN curl https://bootstrap.pypa.io/get-pip.py | python3.6 - virtualenv==16.6.0 p
 RUN apt-get -y install \
         python-virtualenv python-setuptools python-mock && \
         apt-get clean && \
-        git clone -b stackstorm_patched https://github.com/stackstorm/dh-virtualenv.git /tmp/dh-virtualenv && \
+        git clone --branch stackstorm_patched_use_custom_pip https://github.com/StackStorm/dh-virtualenv.git /tmp/dh-virtualenv && \
         cd /tmp/dh-virtualenv && \
         dpkg-buildpackage -b -uc -us && dpkg -i ../dh-virtualenv_*.deb && \
           rm -rf /tmp/dh-virtualenv*


### PR DESCRIPTION
This pull request fixes weird build issues I saw here - https://github.com/StackStorm/st2-packages/pull/687#issuecomment-790941002.

The issue is that Bionic bundles two pip binaries before this change - system one installed via apt which is the old one and one we install using get-pip which is the correct / new one (20.0.2).

And during st2-packages build process, dh-virtualenv picks system one which won't work with new wheels, etc.

This pull request removes system one to ensure only a single pip (aka ltest 20.0.2 is available).

Now the whole Dockerfile also has left cruft and is more in line with Xenial one (which works fine since we don't install two pip versions tehre).